### PR TITLE
Use indranet

### DIFF
--- a/depmap_analysis/network_functions/indra_network.py
+++ b/depmap_analysis/network_functions/indra_network.py
@@ -485,23 +485,23 @@ class IndraNetwork:
         return []
 
     def _loop_common_targets(self, common_targets, source, target, **options):
-        """Order common_targets targets by lowest bs in pair."""
+        """Order common_targets targets by lowest belief in pair."""
         ordered_commons = []
         added_targets = 0
         for ct in common_targets:
             paths1 = self._get_hash_path(path=[source, ct], **options)
             paths2 = self._get_hash_path(path=[target, ct], **options)
             if paths1 and paths2 and paths1[0] and paths2[0]:
-                max_bs1 = max([st['bs'] for st in paths1[0]])
-                max_bs2 = max([st['bs'] for st in paths2[0]])
+                max_belief1 = max([st['belief'] for st in paths1[0]])
+                max_belief2 = max([st['belief'] for st in paths2[0]])
                 ordered_commons.append({
                     ct: [sorted(paths1[0],
-                                key=lambda k: k['bs'],
+                                key=lambda k: k['belief'],
                                 reverse=True),
                          sorted(paths2[0],
-                                key=lambda k: k['bs'],
+                                key=lambda k: k['belief'],
                                 reverse=True)],
-                    'lowest_highest_belief': min(max_bs1, max_bs2)
+                    'lowest_highest_belief': min(max_belief1, max_belief2)
                 })
                 added_targets += 1
                 if added_targets >= self.MAX_PATHS:
@@ -791,7 +791,7 @@ class IndraNetwork:
             return False
 
         # Filter belief score
-        if edge_stmt['bs'] < options['bsco']:
+        if edge_stmt['belief'] < options['bsco']:
             if self.verbose:
                 logger.info('Did not pass belief score')
             return False
@@ -836,8 +836,8 @@ class IndraNetwork:
             return cost
 
     def _aggregated_path_belief(self, path):
-        bs_list = [self.dir_edges[e]['bs'] for e in zip(path[:-1], path[1:])]
-        return nf.ag_belief_score(bs_list)
+        belief_list = [self.dir_edges[e]['belief'] for e in zip(path[:-1], path[1:])]
+        return nf.ag_belief_score(belief_list)
 
     def _get_sort_key(self, path, hash_path, method=None):
         """Calculate a number to sort the path on

--- a/depmap_analysis/network_functions/indra_network.py
+++ b/depmap_analysis/network_functions/indra_network.py
@@ -716,7 +716,7 @@ class IndraNetwork:
         """Return edges from DiGraph or MultiDigraph in a uniform format"""
         if simple_graph:
             try:
-                stmt_edge = self.dir_edges.get((s, o))['stmt_list'][index]
+                stmt_edge = self.dir_edges.get((s, o))['statements'][index]
             except IndexError:
                 # To keep it consistent with below Multi DiGraph implementation
                 stmt_edge = None

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -90,6 +90,9 @@ def sif_dump_df_to_nx_digraph(df, strat_ev_dict, belief_dict,
     else:
         sif_df = df
 
+    if 'hash' in sif_df.columns:
+        sif_df.rename(columns={'hash': 'stmt_hash'}, inplace=True)
+
     if isinstance(belief_dict, str):
         belief_dict = pickle_open(belief_dict)
     elif isinstance(belief_dict, dict):

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -3,6 +3,7 @@ import requests
 import numpy as np
 import pandas as pd
 import networkx as nx
+from os import path
 from decimal import Decimal
 from collections import defaultdict
 import networkx.algorithms.simple_paths as simple_paths
@@ -28,7 +29,7 @@ except KeyError:
                    'INDRA_GROUNDING_SERVICE_URL to `indra/config.ini`')
 
 
-def sif_dump_df_to_nx_digraph(df, belief_dict=None, strat_ev_dict=None,
+def sif_dump_df_to_nx_digraph(df, strat_ev_dict, belief_dict,
                               multi=False, include_entity_hierarchies=True,
                               verbosity=0):
     """Return a NetworkX digraph from a pandas dataframe of a db dump
@@ -38,7 +39,7 @@ def sif_dump_df_to_nx_digraph(df, belief_dict=None, strat_ev_dict=None,
     df : str|pd.DataFrame
         A dataframe, either as a file path to a pickle or a pandas
         DataFrame object
-    belief_dict : str
+    belief_dict : str|dict
         The file path to a belief dict that is keyed by statement hashes
         corresponding to the statement hashes loaded in df
     strat_ev_dict : str
@@ -57,7 +58,6 @@ def sif_dump_df_to_nx_digraph(df, belief_dict=None, strat_ev_dict=None,
     nx_graph : nx.DiGraph or nx.MultiDiGraph
         By default an nx.DiGraph is returned. By setting multi=True,
         an nx.MultiDiGraph is returned instead."""
-    belief_dict = None
     sed = None
     readers = {'medscan', 'rlimsp', 'trips', 'reach', 'sparser', 'isi'}
 
@@ -71,12 +71,10 @@ def sif_dump_df_to_nx_digraph(df, belief_dict=None, strat_ev_dict=None,
     elif isinstance(belief_dict, dict):
         belief_dict = belief_dict
 
-    if isinstance(strat_ev_dict, str):
+    if isinstance(strat_ev_dict, str) and path.isfile(strat_ev_dict):
         sed = pickle_open(strat_ev_dict)
     elif isinstance(strat_ev_dict, dict):
         sed = strat_ev_dict
-    else:
-        logger.info('No stratified evidence dict provided')
 
     # Extend df with these columns:
     #   belief score from provided dict

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -67,7 +67,7 @@ def sif_dump_df_to_nx_digraph(df, strat_ev_dict, belief_dict,
         """Map belief score 'belief' to weight. If the calculation goes below
         precision, return longfloat precision insted to avoid making the
         weight zero."""
-        return np.max(NP_PRECISION, -np.log(belief, dtype=np.longfloat))
+        return np.max([NP_PRECISION, -np.log(belief, dtype=np.longfloat)])
 
     def _weight_mapping(G):
         """Mapping function for adding the weight of the flattened edges

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -451,7 +451,8 @@ def shortest_simple_paths(G, source, target, weight=None, ignore_nodes=None,
 
     >>> from itertools import islice
     >>> def k_shortest_paths(G, source, target, k, weight=None):
-    ...     return list(islice(nx.shortest_simple_paths(G, source, target, weight=weight), k))
+    ...     return list(islice(nx.shortest_simple_paths(G, source, target,
+    ...         weight=weight), k))
     >>> for path in k_shortest_paths(G, 0, 3, 2):
     ...     print(path)
     [0, 1, 2, 3]

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -64,7 +64,10 @@ def sif_dump_df_to_nx_digraph(df, strat_ev_dict, belief_dict,
             (False if all(s.lower() in readers for s in ev_dict) else True)
 
     def _weight_from_belief(belief):
-        return -np.log(belief, dtype=np.longfloat)
+        """Map belief score 'belief' to weight. If the calculation goes below
+        precision, return longfloat precision insted to avoid making the
+        weight zero."""
+        return np.max(NP_PRECISION, -np.log(belief, dtype=np.longfloat))
 
     def _weight_mapping(G):
         """Mapping function for adding the weight of the flattened edges

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -239,8 +239,8 @@ def sif_dump_df_to_nx_digraph(df, strat_ev_dict, belief_dict,
                     ed.pop('agB_ns')
                     if indranet_graph.is_multigraph():
                         # MultiDiGraph
-                        indranet_graph.add_edge(u_for_edge=ed['agA_name'],
-                                                v_for_edge=ed['agB_name'],
+                        indranet_graph.add_edge(ed['agA_name'],
+                                                ed['agB_name'],
                                                 **ed)
                     else:
                         # DiGraph
@@ -252,8 +252,8 @@ def sif_dump_df_to_nx_digraph(df, strat_ev_dict, belief_dict,
                             indranet_graph.edges[(u, v)]['statements'].append(
                                 ed)
                         else:
-                            indranet_graph.add_edge(u_for_edge=u,
-                                                    v_for_edge=v,
+                            indranet_graph.add_edge(u,
+                                                    v,
                                                     belief=1.0,
                                                     weight=1.0,
                                                     statements=[ed])

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -3,9 +3,7 @@ import requests
 import numpy as np
 import pandas as pd
 import networkx as nx
-from os import path
 from decimal import Decimal
-from collections import defaultdict
 import networkx.algorithms.simple_paths as simple_paths
 
 from indra.config import CONFIG_DICT

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -156,9 +156,8 @@ def sif_dump_df_to_nx_digraph(df, belief_dict=None, strat_ev_dict=None,
             # Get name in case it's different than id
             if ns_id_to_nodename.get((ns, _id), None):
                 node = ns_id_to_nodename[(ns, _id)]
-
-            if node not in nx_graph.nodes:
-                nx_graph.add_node(node, ns=ns, id=_id)
+            else:
+                ns_id_to_nodename[(ns, _id)] = node
             node_by_uri[uri] = node
 
             # Add famplex edge
@@ -167,6 +166,8 @@ def sif_dump_df_to_nx_digraph(df, belief_dict=None, strat_ev_dict=None,
                 pnode = pid
                 if ns_id_to_nodename.get((pns, pid), None):
                     pnode = ns_id_to_nodename[(pns, pid)]
+                else:
+                    ns_id_to_nodename[(pns, pid)] = pnode
                 node_by_uri[puri] = pnode
                 # Check if edge already exists
                 if (node, pnode, puri) not in added_pairs:

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -184,7 +184,7 @@ def sif_dump_df_to_nx_digraph(df, strat_ev_dict, belief_dict,
     if sed:
         logger.info('Setting "curated" flag')
         # Map to boolean 'curated' for reader/non-reader
-        sif_df['curated'] = sif_df['evidence'].apply(
+        sif_df['curated'] = sif_df['source_counts'].apply(
             func=lambda ev: False if not ev else (
                 False if all(s.lower() in readers for s in ev) else True
             )

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -35,7 +35,7 @@ def sif_dump_df_to_nx_digraph(df, belief_dict=None, strat_ev_dict=None,
 
     Parameters
     ----------
-    df : str|pandas.DataFrame
+    df : str|pd.DataFrame
         A dataframe, either as a file path to a pickle or a pandas
         DataFrame object
     belief_dict : str
@@ -81,16 +81,13 @@ def sif_dump_df_to_nx_digraph(df, belief_dict=None, strat_ev_dict=None,
     else:
         logger.info('No stratified evidence dict provided')
 
-    # Add as nodes:
-    #   'agA_name', 'agB_name'
-    # Columns to be added as node attributes:
-    #   'agA_ns', 'agA_id', 'agB_ns', 'agB_id'
-    # Columns to be added as edge attributes
-    #   'stmt_type', 'evidence_count', 'hash'
-    # Add from external source:
+    # Extend df with these columns:
     #   belief score from provided dict
     #   stratified evidence count by source
-    #   famplex edges using entity hierarchies
+    # Extend df with famplex rows
+    # 'hash' must exist as column in the input dataframe for merge to work out
+    # Preserve all rows in sif_df, so do left join:
+    # sif_df.merge(other, how='left', on='hash')
 
     if bsd:
         hashes = []

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -71,7 +71,7 @@ def sif_dump_df_to_nx_digraph(df, strat_ev_dict, belief_dict,
     elif isinstance(belief_dict, dict):
         belief_dict = belief_dict
 
-    if isinstance(strat_ev_dict, str) and path.isfile(strat_ev_dict):
+    if isinstance(strat_ev_dict, str):
         sed = pickle_open(strat_ev_dict)
     elif isinstance(strat_ev_dict, dict):
         sed = strat_ev_dict

--- a/depmap_analysis/tests/test_indra_network.py
+++ b/depmap_analysis/tests/test_indra_network.py
@@ -25,9 +25,6 @@ df = make_dataframe(reconvert=True,
                                                db=db),
                     pkl_filename=None)
 
-if 'hash' in df.columns:
-    df.rename(columns={'hash': 'stmt_hash'}, inplace=True)
-
 # Create fake belief dict
 bsd = {}
 for n, h in df['stmt_hash'].iteritems():
@@ -41,7 +38,7 @@ test_hash = 1234567890
 test_row = {
     'agA_ns': 'TEST', 'agA_id': '1234', 'agA_name': test_edge[0],
     'agB_ns': 'TEST', 'agB_id': '2345', 'agB_name': test_edge[1],
-    'stmt_type': 'TestStatement', 'evidence_count': 1, 'hash': test_hash
+    'stmt_type': 'TestStatement', 'evidence_count': 1, 'stmt_hash': test_hash
 }
 test_evidence = {'tester': 1}
 test_belief = 0.987654321
@@ -100,9 +97,9 @@ class TestNetwork(unittest.TestCase):
         assert stmt_dict['stmt_type'] == test_row['stmt_type']
         assert stmt_dict['stmt_hash'] == str(test_row['hash'])
         assert stmt_dict['evidence_count'] == test_row['evidence_count']
-        assert isinstance(stmt_dict['evidence'], dict)
-        assert stmt_dict['evidence'] == test_evidence
-        assert stmt_dict['evidence']['tester'] == test_evidence['tester']
+        assert isinstance(stmt_dict['source_counts'], dict)
+        assert stmt_dict['source_counts'] == test_evidence
+        assert stmt_dict['source_counts']['tester'] == test_evidence['tester']
         assert isinstance(stmt_dict['curated'], bool)
         assert stmt_dict['curated'] is True
         assert stmt_dict['belief'] == test_belief
@@ -129,8 +126,8 @@ class TestNetwork(unittest.TestCase):
         assert isinstance(edge_dict_test['weight'], np.longfloat)
 
         # Check stmt meta data list
-        stmt_list = edge_dict['stmt_list']
-        test_stmt_list = edge_dict_test['stmt_list']
+        stmt_list = edge_dict['statements']
+        test_stmt_list = edge_dict_test['statements']
         assert isinstance(stmt_list, list)
         assert isinstance(test_stmt_list, list)
         assert isinstance(stmt_list[0], dict)
@@ -149,11 +146,11 @@ class TestNetwork(unittest.TestCase):
         assert isinstance(stmt_list[0]['evidence_count'], int)
         assert test_stmt_list[0]['evidence_count'] == 1
 
-        assert isinstance(stmt_list[0]['evidence'], dict)
-        assert isinstance(test_stmt_list[0]['evidence'], dict)
-        assert len(test_stmt_list[0]['evidence']) == 1
-        assert 'tester' in test_stmt_list[0]['evidence']
-        assert test_stmt_list[0]['evidence']['tester'] == 1
+        assert isinstance(stmt_list[0]['source_counts'], dict)
+        assert isinstance(test_stmt_list[0]['source_counts'], dict)
+        assert len(test_stmt_list[0]['source_counts']) == 1
+        assert 'tester' in test_stmt_list[0]['source_counts']
+        assert test_stmt_list[0]['source_counts']['tester'] == 1
 
         assert isinstance(stmt_list[0]['curated'], bool)
         assert test_stmt_list[0]['curated'] is True
@@ -195,11 +192,11 @@ class TestNetwork(unittest.TestCase):
         assert isinstance(edge_dict['evidence_count'], int)
         assert edge_dict_test['evidence_count'] == 1
 
-        assert isinstance(edge_dict['evidence'], dict)
-        assert isinstance(edge_dict_test['evidence'], dict)
-        assert len(edge_dict_test['evidence']) == 1
-        assert 'tester' in edge_dict_test['evidence']
-        assert edge_dict_test['evidence']['tester'] == 1
+        assert isinstance(edge_dict['source_counts'], dict)
+        assert isinstance(edge_dict_test['source_counts'], dict)
+        assert len(edge_dict_test['source_counts']) == 1
+        assert 'tester' in edge_dict_test['source_counts']
+        assert edge_dict_test['source_counts']['tester'] == 1
 
         assert isinstance(edge_dict['curated'], bool)
         assert edge_dict_test['curated'] is True

--- a/depmap_analysis/tests/test_indra_network.py
+++ b/depmap_analysis/tests/test_indra_network.py
@@ -82,11 +82,12 @@ class TestNetwork(unittest.TestCase):
         result = self.indra_network.handle_query(**query)
         assert result['timeout'] is False
         assert isinstance(result['paths_by_node_count'], (dict, defaultdict))
-        assert 2 in result['paths_by_node_count']
-        assert len(result['paths_by_node_count'][2]) == 1
-        assert isinstance(result['paths_by_node_count'][2][0],
+        assert 2 in result['paths_by_node_count']['forward']
+        assert not result['paths_by_node_count']['backward']
+        assert len(result['paths_by_node_count']['forward'][2]) == 1
+        assert isinstance(result['paths_by_node_count']['forward'][2][0],
                           (dict, defaultdict))
-        path_dict = result['paths_by_node_count'][2][0]
+        path_dict = result['paths_by_node_count']['forward'][2][0]
         assert path_dict['path'] == list(test_edge)
         assert isinstance(path_dict['cost'], str)
         assert isinstance(path_dict['sort_key'], str)

--- a/depmap_analysis/tests/test_indra_network.py
+++ b/depmap_analysis/tests/test_indra_network.py
@@ -7,7 +7,7 @@ import indra_db.tests.util as tu
 from indra_db.util.dump_sif import load_db_content, make_ev_strata, \
     make_dataframe, NS_LIST
 
-from depmap_analysis.network_functions.network_functions import \
+from depmap_analysis.network_functions.net_functions import \
     sif_dump_df_to_nx_digraph
 from depmap_analysis.network_functions.indra_network import IndraNetwork
 

--- a/depmap_analysis/tests/test_indra_network.py
+++ b/depmap_analysis/tests/test_indra_network.py
@@ -75,7 +75,8 @@ class TestNetwork(unittest.TestCase):
             'bsco': 0.0,
             'curated_db_only': False,
             'fplx_expand': False,
-            'k_shortest': 1
+            'k_shortest': 1,
+            'two_way': True
         }
 
         result = self.indra_network.handle_query(**query)

--- a/depmap_analysis/tests/test_indra_network.py
+++ b/depmap_analysis/tests/test_indra_network.py
@@ -25,9 +25,12 @@ df = make_dataframe(reconvert=True,
                                                db=db),
                     pkl_filename=None)
 
+if 'hash' in df.columns:
+    df.rename(columns={'hash': 'stmt_hash'}, inplace=True)
+
 # Create fake belief dict
 bsd = {}
-for n, h in df['hash'].iteritems():
+for n, h in df['stmt_hash'].iteritems():
     bsd[h] = rnd()
 
 # Add custom row to df that can be checked later
@@ -102,7 +105,7 @@ class TestNetwork(unittest.TestCase):
         assert stmt_dict['evidence']['tester'] == test_evidence['tester']
         assert isinstance(stmt_dict['curated'], bool)
         assert stmt_dict['curated'] is True
-        assert stmt_dict['bs'] == test_belief
+        assert stmt_dict['belief'] == test_belief
 
     def test_dir_edge_structure(self):
         # Get an edge from test DB
@@ -120,8 +123,8 @@ class TestNetwork(unittest.TestCase):
         edge_dict_test = self.indra_network.dir_edges[test_edge]
         assert isinstance(edge_dict, dict)
         assert isinstance(edge_dict_test, dict)
-        assert isinstance(edge_dict['bs'], (np.longfloat, float))
-        assert isinstance(edge_dict_test['bs'], (np.longfloat, float))
+        assert isinstance(edge_dict['belief'], (np.longfloat, float))
+        assert isinstance(edge_dict_test['belief'], (np.longfloat, float))
         assert isinstance(edge_dict['weight'], np.longfloat)
         assert isinstance(edge_dict_test['weight'], np.longfloat)
 
@@ -155,9 +158,9 @@ class TestNetwork(unittest.TestCase):
         assert isinstance(stmt_list[0]['curated'], bool)
         assert test_stmt_list[0]['curated'] is True
 
-        assert isinstance(stmt_list[0]['bs'], (float, np.longfloat))
-        assert isinstance(test_stmt_list[0]['bs'], (float, np.longfloat))
-        assert test_stmt_list[0]['bs'] == 0.987654321
+        assert isinstance(stmt_list[0]['belief'], (float, np.longfloat))
+        assert isinstance(test_stmt_list[0]['belief'], (float, np.longfloat))
+        assert test_stmt_list[0]['belief'] == 0.987654321
 
     def test_multi_dir_edge_structure(self):
         # Get an edge from test DB
@@ -176,9 +179,9 @@ class TestNetwork(unittest.TestCase):
         assert isinstance(edge_dict, dict)
         assert isinstance(edge_dict_test, dict)
 
-        assert isinstance(edge_dict['bs'], (np.longfloat, float))
-        assert isinstance(edge_dict_test['bs'], (np.longfloat, float))
-        assert edge_dict_test['bs'] == 0.987654321
+        assert isinstance(edge_dict['belief'], (np.longfloat, float))
+        assert isinstance(edge_dict_test['belief'], (np.longfloat, float))
+        assert edge_dict_test['belief'] == 0.987654321
 
         assert isinstance(edge_dict['weight'], (np.longfloat, float))
         assert isinstance(edge_dict_test['weight'], (np.longfloat, float))

--- a/depmap_analysis/tests/test_indra_network.py
+++ b/depmap_analysis/tests/test_indra_network.py
@@ -40,7 +40,8 @@ test_row = {
     'agB_ns': 'TEST', 'agB_id': '2345', 'agB_name': test_edge[1],
     'stmt_type': 'TestStatement', 'evidence_count': 1, 'stmt_hash': test_hash
 }
-test_evidence = {'tester': 1}
+test_source = 'pc11'
+test_evidence = {test_source: 1}
 test_belief = 0.987654321
 df = df.append(test_row,
     ignore_index=True)
@@ -99,7 +100,8 @@ class TestNetwork(unittest.TestCase):
         assert stmt_dict['evidence_count'] == test_row['evidence_count']
         assert isinstance(stmt_dict['source_counts'], dict)
         assert stmt_dict['source_counts'] == test_evidence
-        assert stmt_dict['source_counts']['tester'] == test_evidence['tester']
+        assert stmt_dict['source_counts'][test_source] == \
+               test_evidence[test_source]
         assert isinstance(stmt_dict['curated'], bool)
         assert stmt_dict['curated'] is True
         assert stmt_dict['belief'] == test_belief
@@ -149,8 +151,8 @@ class TestNetwork(unittest.TestCase):
         assert isinstance(stmt_list[0]['source_counts'], dict)
         assert isinstance(test_stmt_list[0]['source_counts'], dict)
         assert len(test_stmt_list[0]['source_counts']) == 1
-        assert 'tester' in test_stmt_list[0]['source_counts']
-        assert test_stmt_list[0]['source_counts']['tester'] == 1
+        assert test_source in test_stmt_list[0]['source_counts']
+        assert test_stmt_list[0]['source_counts'][test_source] == 1
 
         assert isinstance(stmt_list[0]['curated'], bool)
         assert test_stmt_list[0]['curated'] is True
@@ -195,8 +197,8 @@ class TestNetwork(unittest.TestCase):
         assert isinstance(edge_dict['source_counts'], dict)
         assert isinstance(edge_dict_test['source_counts'], dict)
         assert len(edge_dict_test['source_counts']) == 1
-        assert 'tester' in edge_dict_test['source_counts']
-        assert edge_dict_test['source_counts']['tester'] == 1
+        assert test_source in edge_dict_test['source_counts']
+        assert edge_dict_test['source_counts'][test_source] == 1
 
         assert isinstance(edge_dict['curated'], bool)
         assert edge_dict_test['curated'] is True

--- a/depmap_analysis/tests/test_indra_network.py
+++ b/depmap_analysis/tests/test_indra_network.py
@@ -98,7 +98,7 @@ class TestNetwork(unittest.TestCase):
         assert stmt_dict['subj'], stmt_dict['obj'] == test_edge
         assert isinstance(stmt_dict['weight'], (np.longfloat, float))
         assert stmt_dict['stmt_type'] == test_row['stmt_type']
-        assert stmt_dict['stmt_hash'] == str(test_row['hash'])
+        assert stmt_dict['stmt_hash'] == str(test_row['stmt_hash'])
         assert stmt_dict['evidence_count'] == test_row['evidence_count']
         assert isinstance(stmt_dict['source_counts'], dict)
         assert stmt_dict['source_counts'] == test_evidence

--- a/indra_depmap_service/query.html
+++ b/indra_depmap_service/query.html
@@ -353,8 +353,8 @@
       let htmlString = '';
       let badgeStart = '<span class="badge badge-secondary badge-pill float-right ';
       let badgeEnd = '</span>';
-      for (source in stmt.evidence) {
-        htmlString += badgeStart + 'source-'+ source + '">' + source + ': ' + stmt.evidence[source].toString() + badgeEnd
+      for (source in stmt.source_counts) {
+        htmlString += badgeStart + 'source-'+ source + '">' + source + ': ' + stmt.source_counts[source].toString() + badgeEnd
       }
       return htmlString
     }


### PR DESCRIPTION
This PR updates the pipeline that build the graphs used in the INDRA Network Service, using the IndraNet class to build the graphs.

This PR depends on changes in [INDRA](https://github.com/sorgerlab/indra/pull/944).

Other notable changes:
- Keyword `bs` (for **belief score**) is now `belief`
- Keywords `hash` and `evidence` are now `stmt_hash` and `source_counts`, respectively, to conform with usage in IndraNet
- Fix bug where networkx sometimes expect the keyword `u_for_edge` and sometimes `u_of_edge`
