### PR TITLE
Reactome integration and explanation of random pairs

### DIFF
--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -10,8 +10,12 @@ import numpy as np
 from pybel.dsl.node_classes import CentralDogma
 
 from indra.util.multiprocessing_traceback import WrapException
+from indra.databases.hgnc_client import get_current_hgnc_id, get_uniprot_id,\
+    uniprot_ids, get_hgnc_name
 
 logger = logging.getLogger(__name__)
+
+uniprot_ids_reverse = {v: k for k, v in uniprot_ids.items()}
 
 global_results = []
 global_results_pairs = []
@@ -43,11 +47,13 @@ def error_callback(err):
 
 
 class GlobalVars(object):
-    def __init__(self, df=None, z_cm=None, sampl=10):
+    def __init__(self, df=None, z_cm=None, reactome=None, sampl=10):
         if df is not None:
             global_vars['df'] = df
         if sampl:
             global_vars['subset_size'] = sampl
+        if reactome:
+            global_vars['reactome'] = reactome
         if z_cm is not None:
             global list_of_genes
             global_vars['z_cm'] = z_cm
@@ -245,81 +251,103 @@ def get_corr_stats(so_pairs):
         global list_of_genes
         df = global_vars['df']
         z_corr = global_vars['z_cm']
+        reactome = global_vars['reactome']
         subset_size = global_vars['subset_size']
         chunk_size = max(len(list_of_genes[:]) // subset_size, 1)
 
         all_axb_corrs = []
         top_axb_corrs = []
-        azb_avg_corrs = []
-        all_azb_corrs = []
         axb_avg_corrs = []
 
+        azb_avg_corrs = []
+        all_azb_corrs = []
+
+        reactome_avg_corrs = []
+        all_reactome_corrs = []
+
         # reset counters
-        counter = Counter({'z_nans': 0,
+        counter = Counter({'r_skip': 0,
                            'z_skip': 0,
                            'x_skip': 0})
 
         for subj, obj in so_pairs:
-            ab_avg_corrs = []
-            path_rows = df[(df['agA'] == subj) &
-                           (df['agB'] == obj) &
-                           ((df['expl type'] == 'a-x-b') |
-                            (df['expl type'] == 'b-x-a') |
-                           (df['expl type'] == 'shared target'))]
-
-            # Make sure we don't double-count Xs such that X is shared target
-            # and also a pathway; also, don't include X if X = subj or obj
-            x_set = set()
-            for ix, path_row in path_rows.iterrows():
-                x_set.update([x for x in path_row['expl data']
-                              if x not in (subj, obj)])
-
-            for x in x_set:
-                x_name = x.name if isinstance(x, CentralDogma) else x
-                if x_name in z_corr.columns:
-                    ax_corr = z_corr.loc[subj, x_name]
-                    xb_corr = z_corr.loc[x_name, obj]
-                    all_axb_corrs += [ax_corr, xb_corr]
-                    avg_corr = 0.5 * abs(ax_corr) + 0.5 * abs(xb_corr)
-                    ab_avg_corrs.append(avg_corr)
-                    axb_avg_corrs.append(avg_corr)
-                else:
-                    counter.update('x_skip')
-                    continue
-
-            # Get a random subset of the possible correlation z scores
-            for z in np.random.choice(list_of_genes[:], chunk_size, False):
-                try:
-                    if z == subj or z == obj:
-                        counter.update('z_skip')
-                        continue
-                    az_corr = z_corr.loc[z, subj]
-                    bz_corr = z_corr.loc[z, obj]
-                    if np.isnan(az_corr) or np.isnan(bz_corr):
-                        # Is there a more efficient way of doing this?
-                        logger.info(
-                            f'NaN correlations for '
-                            f'subj-z ({str(subj)}-{str(z)}) or '
-                            f'obj-z ({str(obj)}-{str(z)})'
-                        )
-                        counter.update('z_nans')
-                        continue
-                    all_azb_corrs.extend([az_corr, bz_corr])
-                    azb_avg_corrs.append(0.5 * abs(az_corr) + 0.5 * abs(bz_corr))
-                except KeyError as err:
-                    raise KeyError(
-                        f'KeyError was raised trying to sample background '
-                        f'correlation distribution with subject {str(subj)}'
-                        f'({subj.__class__}), object {str(obj)} '
-                        f'({obj.__class__}) and z {z} ({z.__class__})'
-                    ) from err
-            # if warn:
-            #     logger.warning('%d missing X genes out of %d in correlation '
-            #                    'matrices' % (warn, len(x_list)))
-            if len(ab_avg_corrs) > 0:
-                max_magn_avg = max(ab_avg_corrs)
+            # Get x values
+            (avg_x_corrs_per_ab, axb_corrs), x_len = \
+                get_interm_corr_stats_x(subj, obj, z_corr, df)
+            all_axb_corrs += axb_corrs
+            if len(avg_x_corrs_per_ab) > 0:
+                max_magn_avg = max(avg_x_corrs_per_ab)
+                axb_avg_corrs += avg_x_corrs_per_ab
                 top_axb_corrs.append((subj, obj, max_magn_avg))
-                #ab_to_axb_avg.append((subj, obj, comb_zsc, max_magn_avg))
+            counter['x_skip'] += x_len - len(avg_x_corrs_per_ab)
+
+            # Get z values
+            z_iter = np.random.choice(list_of_genes[:], chunk_size, False)
+            avg_z_corrs_per_ab, azb_corrs = \
+                get_interm_corr_stats_z(subj, obj, z_iter, z_corr)
+            azb_avg_corrs += avg_z_corrs_per_ab
+            all_azb_corrs += azb_corrs
+            counter['z_skip'] += len(z_iter) - len(avg_z_corrs_per_ab)
+
+            # Get reactome values
+            (avg_reactome_corrs_per_ab, reactome_corrs), r_len = \
+                get_interm_corr_stats_reactome(subj, obj, reactome, z_corr)
+            reactome_avg_corrs += avg_reactome_corrs_per_ab
+            counter['r_skip'] += r_len - len(avg_reactome_corrs_per_ab)
+
+            ## OLD ##
+
+            # path_rows = df[(df['agA'] == subj) &
+            #                (df['agB'] == obj) &
+            #                ((df['expl type'] == 'a-x-b') |
+            #                 (df['expl type'] == 'b-x-a') |
+            #                (df['expl type'] == 'shared target'))]
+            #
+            # # Make sure we don't double-count Xs such that X is shared target
+            # # and also a pathway; also, don't include X if X = subj or obj
+            # x_set = set()
+            # for ix, path_row in path_rows.iterrows():
+            #     x_set.update([x for x in path_row['expl data']
+            #                   if x not in (subj, obj)])
+            #
+            # for x in x_set:
+            #     x_name = x.name if isinstance(x, CentralDogma) else x
+            #     if x_name in z_corr.columns:
+            #         ax_corr = z_corr.loc[subj, x_name]
+            #         xb_corr = z_corr.loc[x_name, obj]
+            #         all_axb_corrs += [ax_corr, xb_corr]
+            #         avg_corr = 0.5 * abs(ax_corr) + 0.5 * abs(xb_corr)
+            #         avg_x_corrs_per_ab.append(avg_corr)
+            #     else:
+            #         continue
+            #
+            # # Get a random subset of the possible correlation z scores
+            # for z in np.random.choice(list_of_genes[:], chunk_size, False):
+            #     try:
+            #         if z == subj or z == obj:
+            #             counter.update('z_skip')
+            #             continue
+            #         az_corr = z_corr.loc[z, subj]
+            #         bz_corr = z_corr.loc[z, obj]
+            #         if np.isnan(az_corr) or np.isnan(bz_corr):
+            #             # Is there a more efficient way of doing this?
+            #             logger.info(
+            #                 f'NaN correlations for '
+            #                 f'subj-z ({str(subj)}-{str(z)}) or '
+            #                 f'obj-z ({str(obj)}-{str(z)})'
+            #             )
+            #             continue
+            #         all_azb_corrs.extend([az_corr, bz_corr])
+            #         azb_avg_corrs.append(0.5*abs(az_corr) + 0.5*abs(bz_corr))
+            #     except KeyError as err:
+            #         raise KeyError(
+            #             f'KeyError was raised trying to sample background '
+            #             f'correlation distribution with subject {str(subj)}'
+            #             f'({subj.__class__}), object {str(obj)} '
+            #             f'({obj.__class__}) and z {z} ({z.__class__})'
+            #         ) from err
+
+        # TODO Add reactome output to returned dict
         assert all(len(cl) for cl in [all_axb_corrs, axb_avg_corrs,
                                       top_axb_corrs, all_azb_corrs,
                                       azb_avg_corrs]),\
@@ -341,3 +369,93 @@ def get_corr_stats(so_pairs):
                 'azb_avg_corrs': azb_avg_corrs}
     except Exception:
         raise WrapException()
+
+
+def get_interm_corr_stats_x(subj, obj, z_corr, df):
+    path_rows = df[(df['agA'] == subj) &
+                   (df['agB'] == obj) &
+                   ((df['expl type'] == 'a-x-b') |
+                    (df['expl type'] == 'b-x-a') |
+                    (df['expl type'] == 'shared target'))]
+    x_set = set()
+    for ix, path_row in path_rows.iterrows():
+        x_set.update([x for x in path_row['expl data']
+                      if x not in (subj, obj)])
+    return _get_interm_corr_stats(subj, obj, x_set, z_corr), len(x_set)
+
+
+def get_interm_corr_stats_z(subj, obj, z_set, z_corr):
+    return _get_interm_corr_stats(subj, obj, z_set, z_corr)
+
+
+def get_interm_corr_stats_reactome(subj, obj, reactome, z_corr):
+    pathways_by_gene, genes_by_pathway, _ = reactome
+    subj_up = _hgncsym2up(subj)
+    if subj_up is None:
+        return [], []
+    obj_up = _hgncsym2up(obj)
+    if obj_up is None:
+        return [], []
+
+    paths = set(pathways_by_gene[subj_up]) & set(pathways_by_gene[obj_up])
+    gene_set = set()
+    for rp in paths:
+        gene_set.update([g for g in genes_by_pathway[rp]])
+    hgnc_gene_set = [_up2hgncsym(up) for up in gene_set]
+    return _get_interm_corr_stats(subj, obj, hgnc_gene_set, z_corr),\
+           len(hgnc_gene_set)
+
+
+def _get_interm_corr_stats(a, b, y_set, z_corr):
+    # Get a list of the maximum ax-bx average per pair
+    avg_y_corrs_per_ab = []
+
+    # Get all ax and bc correlations
+    all_ayb_corrs = []
+
+    for y in y_set:
+        try:
+            # Skip self correlations and non-existing names
+            if y is None or y == a or y == b or y not in z_corr.columns:
+                continue
+            ay_corr = z_corr.loc[y, a]
+            by_corr = z_corr.loc[y, b]
+            if np.isnan(ay_corr) or np.isnan(by_corr):
+                # Is there a more efficient way of doing this?
+                logger.info(
+                    f'NaN correlations for subj-y ({str(a)}-{str(y)}) or '
+                    f'obj-y ({str(b)}-{str(y)})'
+                )
+                continue
+
+            all_ayb_corrs += [ay_corr, by_corr]
+            avg_y_corrs_per_ab.append(0.5*(abs(ay_corr) + abs(by_corr)))
+
+        except KeyError as ke:
+            raise KeyError(
+                f'KeyError was raised trying to sample '
+                f'correlation distribution with subject {str(a)}'
+                f'({a.__class__}), object {str(b)} '
+                f'({b.__class__}) and intermediate {str(y)} ({y.__class__})'
+            ) from ke
+    return avg_y_corrs_per_ab, all_ayb_corrs
+
+
+def _hgncsym2up(hgnc_symb):
+    hgnc_id = get_current_hgnc_id(hgnc_symb)
+    if isinstance(hgnc_id, list):
+        ix = 0
+        upid = None
+        while upid is None:
+            try:
+                upid = get_uniprot_id(hgnc_id[ix])
+            except IndexError:
+                break
+            ix += 1
+    else:
+        upid = get_uniprot_id(hgnc_id)
+    return upid
+
+
+def _up2hgncsym(up_id):
+    return get_hgnc_name(uniprot_ids_reverse(up_id)) or None

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -255,7 +255,7 @@ def get_corr_stats(so_pairs):
         global list_of_genes
         df = global_vars['df']
         z_corr = global_vars['z_cm']
-        reactome = global_vars['reactome']
+        reactome = global_vars.get('reactome')
         subset_size = global_vars['subset_size']
         chunk_size = max(len(list_of_genes[:]) // subset_size, 1)
 
@@ -294,17 +294,19 @@ def get_corr_stats(so_pairs):
             counter['z_skip'] += len(z_iter) - len(avg_z_corrs_per_ab)
 
             # Get reactome values
-            (avg_reactome_corrs_per_ab, reactome_corrs), r_len = \
-                get_interm_corr_stats_reactome(subj, obj, reactome, z_corr)
-            reactome_avg_corrs += avg_reactome_corrs_per_ab
-            all_reactome_corrs += reactome_corrs
-            counter['r_skip'] += r_len - len(avg_reactome_corrs_per_ab)
+            if reactome:
+                (avg_reactome_corrs_per_ab, reactome_corrs), r_len = \
+                    get_interm_corr_stats_reactome(subj, obj, reactome, z_corr)
+                reactome_avg_corrs += avg_reactome_corrs_per_ab
+                all_reactome_corrs += reactome_corrs
+                counter['r_skip'] += r_len - len(avg_reactome_corrs_per_ab)
 
+        assert_list = [all_axb_corrs, axb_avg_corrs, top_axb_corrs,
+                       all_azb_corrs, azb_avg_corrs]
+        if reactome:
+            assert_list += [all_reactome_corrs, reactome_avg_corrs]
         try:
-            assert all(len(cl) for cl in [all_axb_corrs, axb_avg_corrs,
-                                          top_axb_corrs, all_azb_corrs,
-                                          azb_avg_corrs, all_reactome_corrs,
-                                          reactome_avg_corrs])
+            assert all(len(cl) for cl in assert_list)
         except AssertionError as exc:
             raise ValueError(
                 f'Zero or partial results in process '
@@ -313,8 +315,8 @@ def get_corr_stats(so_pairs):
                 f'axb_avg_corrs: {len(axb_avg_corrs)}, '
                 f'top_axb_corrs: {len(top_axb_corrs)}, '
                 f'all_azb_corrs: {len(all_azb_corrs)}, '
-                f'azb_avg_corrs: {len(azb_avg_corrs)} ',
-                f'all_reactome_corrs: {len(all_reactome_corrs)} ',
+                f'azb_avg_corrs: {len(azb_avg_corrs)}, '
+                f'all_reactome_corrs: {len(all_reactome_corrs)}, '
                 f'reactome_avg_corrs: {len(reactome_avg_corrs)}'
             ) from exc
 

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -300,58 +300,6 @@ def get_corr_stats(so_pairs):
             all_reactome_corrs += reactome_corrs
             counter['r_skip'] += r_len - len(avg_reactome_corrs_per_ab)
 
-            ## OLD ##
-
-            # path_rows = df[(df['agA'] == subj) &
-            #                (df['agB'] == obj) &
-            #                ((df['expl type'] == 'a-x-b') |
-            #                 (df['expl type'] == 'b-x-a') |
-            #                (df['expl type'] == 'shared target'))]
-            #
-            # # Make sure we don't double-count Xs such that X is shared target
-            # # and also a pathway; also, don't include X if X = subj or obj
-            # x_set = set()
-            # for ix, path_row in path_rows.iterrows():
-            #     x_set.update([x for x in path_row['expl data']
-            #                   if x not in (subj, obj)])
-            #
-            # for x in x_set:
-            #     x_name = x.name if isinstance(x, CentralDogma) else x
-            #     if x_name in z_corr.columns:
-            #         ax_corr = z_corr.loc[subj, x_name]
-            #         xb_corr = z_corr.loc[x_name, obj]
-            #         all_axb_corrs += [ax_corr, xb_corr]
-            #         avg_corr = 0.5 * abs(ax_corr) + 0.5 * abs(xb_corr)
-            #         avg_x_corrs_per_ab.append(avg_corr)
-            #     else:
-            #         continue
-            #
-            # # Get a random subset of the possible correlation z scores
-            # for z in np.random.choice(list_of_genes[:], chunk_size, False):
-            #     try:
-            #         if z == subj or z == obj:
-            #             counter.update('z_skip')
-            #             continue
-            #         az_corr = z_corr.loc[z, subj]
-            #         bz_corr = z_corr.loc[z, obj]
-            #         if np.isnan(az_corr) or np.isnan(bz_corr):
-            #             # Is there a more efficient way of doing this?
-            #             logger.info(
-            #                 f'NaN correlations for '
-            #                 f'subj-z ({str(subj)}-{str(z)}) or '
-            #                 f'obj-z ({str(obj)}-{str(z)})'
-            #             )
-            #             continue
-            #         all_azb_corrs.extend([az_corr, bz_corr])
-            #         azb_avg_corrs.append(0.5*abs(az_corr) + 0.5*abs(bz_corr))
-            #     except KeyError as err:
-            #         raise KeyError(
-            #             f'KeyError was raised trying to sample background '
-            #             f'correlation distribution with subject {str(subj)}'
-            #             f'({subj.__class__}), object {str(obj)} '
-            #             f'({obj.__class__}) and z {z} ({z.__class__})'
-            #         ) from err
-
         try:
             assert all(len(cl) for cl in [all_axb_corrs, axb_avg_corrs,
                                           top_axb_corrs, all_azb_corrs,

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -458,4 +458,4 @@ def _hgncsym2up(hgnc_symb):
 
 
 def _up2hgncsym(up_id):
-    return get_hgnc_name(uniprot_ids_reverse(up_id)) or None
+    return get_hgnc_name(uniprot_ids_reverse[up_id]) or None

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -94,9 +94,10 @@ class GlobalVars(object):
         """Same as assert_global_vars but with the shared array as well"""
         df_exists = global_vars.get('df', False) is not False
         z_cm_exists = global_vars.get('z_cm', False) is not False
+        reactome_exists = global_vars.get('reactome', False) is not False
         ssize_exists = global_vars.get('subset_size', False) is not False
         shared_ar_exists = bool(len(list_of_genes[:]))
-        return df_exists and z_cm_exists and \
+        return df_exists and z_cm_exists and reactome_exists and \
             ssize_exists and shared_ar_exists
 
 
@@ -230,19 +231,22 @@ def get_corr_stats_mp(so_pairs, max_proc=cpu_count()):
     logger.info(f'Done at {datetime.now().strftime("%H:%M:%S")}')
 
     logger.info(f'Assembling {len(global_results)} results')
-    results = [[], [], [], [], []]
+    results = [[], [], [], [], [], [], []]
     for done_res in global_results:
         # Var name: all_x_corrs; Dict key: 'all_axb_corrs'
-        results[0].extend(done_res['all_axb_corrs'])
+        results[0] += done_res['all_axb_corrs']
         # Var name: avg_x_corrs; Dict key: axb_avg_corrs
-        results[1].extend(done_res['axb_avg_corrs'])
+        results[1] += done_res['axb_avg_corrs']
         # Var name: top_x_corrs; Dict key: top_axb_corrs
-        results[2].extend(done_res['top_axb_corrs'])
+        results[2] += done_res['top_axb_corrs']
         # Var name: all_azb_corrs; Dict key: all_azb_corrs
-        results[3].extend(done_res['all_azb_corrs'])
+        results[3] += done_res['all_azb_corrs']
         # Var name: azb_avg_corrs; Dict key: azb_avg_corrs
-        results[4].extend(done_res['azb_avg_corrs'])
-
+        results[4] += done_res['azb_avg_corrs']
+        # Var name: all_reactome_corrs; Dict key: all_reactome_corrs
+        results[5] += done_res['all_reactome_corrs']
+        # Var name: reactome_avg_corrs; Dict key: reactome_avg_corrs
+        results[6] += done_res['reactome_avg_corrs']
     return results
 
 
@@ -293,6 +297,7 @@ def get_corr_stats(so_pairs):
             (avg_reactome_corrs_per_ab, reactome_corrs), r_len = \
                 get_interm_corr_stats_reactome(subj, obj, reactome, z_corr)
             reactome_avg_corrs += avg_reactome_corrs_per_ab
+            all_reactome_corrs += reactome_corrs
             counter['r_skip'] += r_len - len(avg_reactome_corrs_per_ab)
 
             ## OLD ##
@@ -366,7 +371,9 @@ def get_corr_stats(so_pairs):
                 'axb_avg_corrs': axb_avg_corrs,
                 'top_axb_corrs': top_axb_corrs,
                 'all_azb_corrs': all_azb_corrs,
-                'azb_avg_corrs': azb_avg_corrs}
+                'azb_avg_corrs': azb_avg_corrs,
+                'all_reactome_corrs': all_reactome_corrs,
+                'reactome_avg_corrs': reactome_avg_corrs}
     except Exception:
         raise WrapException()
 

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -79,7 +79,7 @@ class GlobalVars(object):
     def assert_global_vars(varnames):
         """
 
-        varname : set(str)
+        varnames : set(str)
             Set of names of variables to check if they exists
 
         Returns
@@ -352,20 +352,33 @@ def get_corr_stats(so_pairs):
             #             f'({obj.__class__}) and z {z} ({z.__class__})'
             #         ) from err
 
-        # TODO Add reactome output to returned dict
-        assert all(len(cl) for cl in [all_axb_corrs, axb_avg_corrs,
-                                      top_axb_corrs, all_azb_corrs,
-                                      azb_avg_corrs]),\
-            logger.error(f'No results for process {current_process().pid}. '
-                         f'Stats:\nall_axb_corrs: {len(all_axb_corrs)}, '
-                         f'axb_avg_corrs: {len(axb_avg_corrs)}, '
-                         f'top_axb_corrs: {len(top_axb_corrs)}, '
-                         f'all_azb_corrs: {len(all_azb_corrs)}, '
-                         f'azb_avg_corrs: {len(azb_avg_corrs)}')
+        try:
+            assert all(len(cl) for cl in [all_axb_corrs, axb_avg_corrs,
+                                          top_axb_corrs, all_azb_corrs,
+                                          azb_avg_corrs, all_reactome_corrs,
+                                          reactome_avg_corrs])
+        except AssertionError as exc:
+            raise ValueError(
+                f'Zero or partial results in process '
+                f'({current_process().pid}). '
+                f'Stats: all_axb_corrs: {len(all_axb_corrs)}, '
+                f'axb_avg_corrs: {len(axb_avg_corrs)}, '
+                f'top_axb_corrs: {len(top_axb_corrs)}, '
+                f'all_azb_corrs: {len(all_azb_corrs)}, '
+                f'azb_avg_corrs: {len(azb_avg_corrs)} ',
+                f'all_reactome_corrs: {len(all_reactome_corrs)} ',
+                f'reactome_avg_corrs: {len(reactome_avg_corrs)}'
+            ) from exc
 
+        logger.info('Counting skips...')
+        skip_tot = 0
         for k, v in counter.items():
             if v > 0:
                 logger.info(f'Skipped {k} {v} times')
+                skip_tot += v
+
+        if skip_tot == 0:
+            logger.info('No skips made')
 
         return {'all_axb_corrs': all_axb_corrs,
                 'axb_avg_corrs': axb_avg_corrs,

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -458,4 +458,4 @@ def _hgncsym2up(hgnc_symb):
 
 
 def _up2hgncsym(up_id):
-    return get_hgnc_name(uniprot_ids_reverse[up_id]) or None
+    return get_hgnc_name(uniprot_ids_reverse.get(up_id))

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -142,8 +142,14 @@ def main(expl_df, z_corr, reactome=None, eval_str=False, max_proc=None,
         options['max_proc'] = max_proc
 
     # Set and assert existence of global variables
-    gbv.update_global_vars(z_cm=z_corr, reactome=reactome)
-    if gbv.assert_vars():
+    assert_vars = {'z_cm', 'df'}
+    if reactome is not None:
+        gbv.update_global_vars(z_cm=z_corr, reactome=reactome)
+        assert_vars.add('reactome')
+    else:
+        logger.info('No reactome file provided')
+        gbv.update_global_vars(z_cm=z_corr)
+    if gbv.assert_global_vars(assert_vars):
         all_x_corrs_no_direct, \
         avg_x_corrs_no_direct, \
         top_x_corrs_no_direct, \

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('DepMap Corr Stats')
 logger.setLevel(logging.INFO)
 
 
-def main(expl_df, z_corr, eval_str=False, max_proc=None,
+def main(expl_df, z_corr, reactome=None, eval_str=False, max_proc=None,
          max_corr_pairs=10000, do_mp_pairs=True):
     """Get statistics of the correlations associated with different
     explanation types
@@ -29,6 +29,12 @@ def main(expl_df, z_corr, eval_str=False, max_proc=None,
         of genes in z_corr
     z_corr : pd.DataFrame
         A pd.DataFrame of correlation z scores
+    reactome : tuple[dict]|list[dict]
+        A tuple or list of dicts. The first dict is expected to contain
+        mappings from UP IDs of genes to Reactome pathway IDs. The second
+        dict is expected to contain the reverse mapping (i.e Reactome IDs
+        to UP IDs). The third dict is expected to contain mappings from the
+        Reactome IDs to their descriptions.
     eval_str : bool
         If True, run ast.literal_eval() on the 'expl data' column of expl_df
     max_proc : int > 0
@@ -136,11 +142,15 @@ def main(expl_df, z_corr, eval_str=False, max_proc=None,
         options['max_proc'] = max_proc
 
     # Set and assert existence of global variables
-    gbv.update_global_vars(z_cm=z_corr)
+    gbv.update_global_vars(z_cm=z_corr, reactome=reactome)
     if gbv.assert_vars():
-        all_x_corrs_no_direct, avg_x_corrs_no_direct, top_x_corrs_no_direct, \
-            all_azb_corrs_no_direct, azb_avg_corrs_no_direct = \
-            get_corr_stats_mp(**options)
+        all_x_corrs_no_direct, \
+        avg_x_corrs_no_direct, \
+        top_x_corrs_no_direct, \
+        all_azb_corrs_no_direct, \
+        azb_avg_corrs_no_direct, \
+        all_reactome_corrs, \
+        reactome_avg_corrs = get_corr_stats_mp(**options)
     else:
         raise ValueError('Global variables could not be set')
 
@@ -178,7 +188,9 @@ def main(expl_df, z_corr, eval_str=False, max_proc=None,
                             'avg_x_corrs': avg_x_corrs_no_direct,
                             'top_x_corrs': top_x_corrs_no_direct,
                             'all_azb_corrs': all_azb_corrs_no_direct,
-                            'azb_avg_corrs': azb_avg_corrs_no_direct}}
+                            'azb_avg_corrs': azb_avg_corrs_no_direct,
+                            'all_reactome_corrs': all_reactome_corrs,
+                            'reactome_avg_corrs': reactome_avg_corrs}}
 
 
 if __name__ == '__main__':

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -160,36 +160,6 @@ def main(expl_df, z_corr, reactome=None, eval_str=False, max_proc=None,
     else:
         raise ValueError('Global variables could not be set')
 
-    """
-    # a-x-b (with and without direct)
-    logger.info("Getting correlations for all a-x-b (direct and indirect)")
-    all_x_corrs_union, avg_x_corrs_union, top_x_corrs_union, \
-            all_azb_corrs_union, azb_avg_corrs_union = \
-        get_corr_stats(df=expl_df, crispr_cm=crispr_corr_matrix,
-                       rnai_cm=rnai_corr_matrix, so_pairs=ab_axb_union)
-    """
-
-    # All corrs for range (all pairs regardless of explanation type)
-    # all_x_corrs, top_x_corrs, corr_vs_maxavg = \
-    #     get_corr_stats(df=expl_df, crispr_cm=crispr_corr_matrix,
-    #                    rnai_cm=rnai_corr_matrix, so_pairs=all_ab_corr_pairs)
-    """
-    return {'axb_and_dir': {'all_x_corrs': all_x_corrs_direct,
-                            'avg_x_corrs': avg_x_corrs_direct,
-                            'top_x_corrs': top_x_corrs_direct,
-                            'all_azb_corrs': all_azb_corrs_direct,
-                            'azb_avg_corrs': azb_avg_corrs_direct},
-            'axb_not_dir': {'all_x_corrs': all_x_corrs_no_direct,
-                            'avg_x_corrs': avg_x_corrs_no_direct,
-                            'top_x_corrs': top_x_corrs_no_direct,
-                            'all_azb_corrs': all_azb_corrs_no_direct,
-                            'azb_avg_corrs': azb_avg_corrs_no_direct},
-            'all_axb': {'all_x_corrs': all_x_corrs_union,
-                        'avg_x_corrs': avg_x_corrs_union,
-                        'top_x_corrs': top_x_corrs_union,
-                        'all_azb_corrs': all_azb_corrs_union,
-                        'azb_avg_corrs': azb_avg_corrs_union}}
-    """
     return {'axb_not_dir': {'all_x_corrs': all_x_corrs_no_direct,
                             'avg_x_corrs': avg_x_corrs_no_direct,
                             'top_x_corrs': top_x_corrs_no_direct,

--- a/depmap_analysis/scripts/depmap_script2.py
+++ b/depmap_analysis/scripts/depmap_script2.py
@@ -252,9 +252,7 @@ def match_correlations(corr_z, sd_range, script_settings, **kwargs):
                                   iterable=corr_matrix_to_generator(corr_z))
         for chunk in chunk_iter:
             pool.apply_async(func=_match_correlation_body,
-                             # corr_iter, expl_types, stats_columns,
-                             # expl_columns, bool_columns, min_columns,
-                             # explained_set, _type
+                             # args should match the args for func
                              args=(
                                  chunk,
                                  expl_types,

--- a/depmap_analysis/scripts/depmap_script2.py
+++ b/depmap_analysis/scripts/depmap_script2.py
@@ -692,6 +692,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser('DepMap Explainer main script')
     #   1a Load depmap data from scratch | load crispr/rnai raw corr | z-score
     corr_group = parser.add_mutually_exclusive_group(required=True)
+    range_group = parser.add_mutually_exclusive_group(required=True)
     corr_group.add_argument(
         '--raw-data', nargs=2, type=file_path(),
         help='File paths to CRISPR raw data and RNAi raw data from the '
@@ -742,9 +743,14 @@ if __name__ == '__main__':
              f'{allowed_types}'
     )
 
-    #   2. Filter to SD range
-    parser.add_argument('--sd-range', nargs='+', type=float, required=True,
-                        help='SD range to filter to')
+    #   2a. Filter to SD range
+    range_group.add_argument('--sd-range', nargs='+', type=float,
+                             help='SD range to filter to')
+    # OR do random sampling from correlation matrix genes
+    range_group.add_argument('--random', action='store_true',
+                             help='Check the explanation rate for randomly '
+                                  'sampled pairs of genes from the full '
+                                  'correlation matrix')
     #   3. Ignore list as file
     parser.add_argument(
         '--ignore-list', type=str,

--- a/depmap_analysis/scripts/depmap_script2.py
+++ b/depmap_analysis/scripts/depmap_script2.py
@@ -503,8 +503,8 @@ def error_callback(err):
     logger.exception(err)
 
 
-def main(indra_net, sd_range, outname, graph_type, z_score=None,
-         z_score_file=None, raw_data=None, raw_corr=None,
+def main(indra_net, outname, graph_type, sd_range=None, random=False,
+         z_score=None, z_score_file=None, raw_data=None, raw_corr=None,
          pb_node_mapping=None, n_chunks=256, ignore_list=None, info=None,
          indra_date=None, indra_net_file=None, depmap_date=None,
          sample_size=None, shuffle=False):
@@ -513,9 +513,10 @@ def main(indra_net, sd_range, outname, graph_type, z_score=None,
     Parameters
     ----------
     indra_net : nx.DiGraph|nx.MultiDiGraph
-    sd_range : tuple(float|None)
     outname : str
     graph_type : str
+    sd_range : tuple(float|None)
+    random : bool
     z_score : pd.DataFrame|str
     z_score_file : str
     raw_data : str
@@ -542,10 +543,11 @@ def main(indra_net, sd_range, outname, graph_type, z_score=None,
     run_options = {'n-chunks': n_chunks}
 
     # 1 Check options
-    sd_l, sd_u = sd_range if len(sd_range) == 2 else \
-        ((sd_range[0], None) if len(sd_range) == 1 else (None, None))
+    sd_l, sd_u = sd_range if sd_range and len(sd_range) == 2 else \
+        ((sd_range[0], None) if sd_range and len(sd_range) == 1 else
+         (None, None))
 
-    if not sd_l and not sd_u:
+    if not random and not sd_l and not sd_u:
         raise ValueError('Must specify at least a lower bound for the SD '
                          'range')
 
@@ -595,19 +597,26 @@ def main(indra_net, sd_range, outname, graph_type, z_score=None,
         else:
             raise ValueError('Could not load pybel node mapping')
 
-    # 2. Filter to SD range
-    if sd_l and sd_u:
-        logger.info(f'Filtering correlations to {sd_l} - {sd_u} SD')
-        z_corr = z_corr[((z_corr > sd_l) & (z_corr < sd_u)) |
-                        ((z_corr < -sd_l) & (z_corr > -sd_u))]
-    elif sd_l and not sd_u:
-        logger.info(f'Filtering correlations to {sd_l}+ SD')
-        z_corr = z_corr[(z_corr > sd_l) | (z_corr < -sd_l)]
+    # 2. Filter to SD range OR run random sampling
+    if random:
+        logger.info('Doing random sampling through df.sample')
+        z_corr = z_corr.sample(142, axis=0)
+        z_corr = z_corr.filter(list(z_corr.index), axis=1)
+        # Remove correlation values to not confuse with real data
+        z_corr.loc[:, :] = 0
+    else:
+        if sd_l and sd_u:
+            logger.info(f'Filtering correlations to {sd_l} - {sd_u} SD')
+            z_corr = z_corr[((z_corr > sd_l) & (z_corr < sd_u)) |
+                            ((z_corr < -sd_l) & (z_corr > -sd_u))]
+        elif isinstance(sd_l, (int, float)) and sd_l and not sd_u:
+            logger.info(f'Filtering correlations to {sd_l}+ SD')
+            z_corr = z_corr[(z_corr > sd_l) | (z_corr < -sd_l)]
 
     run_options['sd_range'] = (sd_l, sd_u) if sd_u else (sd_l, None)
 
     # Pick a sample
-    if sample_size is not None:
+    if sample_size is not None and not random:
         logger.info(f'Reducing correlation matrix to a random approximately '
                     f'{sample_size} correlation pairs.')
         row_samples = len(z_corr) - 1
@@ -626,7 +635,7 @@ def main(indra_net, sd_range, outname, graph_type, z_score=None,
             row_samples = row_samples - 1 if mm >= row_samples else mm
 
     # Shuffle corr matrix without removing items
-    elif shuffle:
+    elif shuffle and not random:
         logger.info('Shuffling correlation matrix...')
         z_corr = z_corr.sample(frac=1, axis=0)
         z_corr = z_corr.filter(list(z_corr.index), axis=1)
@@ -665,6 +674,7 @@ def main(indra_net, sd_range, outname, graph_type, z_score=None,
                                       'z_score': z_score if isinstance(
                                           z_score, str) else
                                       (z_score_file or 'no info'),
+                                      'random': random,
                                       'indranet': indra_net_file or 'no info',
                                       'shuffle': shuffle,
                                       'sample_size': sample_size,
@@ -746,7 +756,8 @@ if __name__ == '__main__':
     #   2a. Filter to SD range
     range_group.add_argument('--sd-range', nargs='+', type=float,
                              help='SD range to filter to')
-    # OR do random sampling from correlation matrix genes
+    # OR
+    #   2b. do random sampling from correlation matrix genes
     range_group.add_argument('--random', action='store_true',
                              help='Check the explanation rate for randomly '
                                   'sampled pairs of genes from the full '

--- a/depmap_analysis/scripts/gather_all_corr_stats.py
+++ b/depmap_analysis/scripts/gather_all_corr_stats.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 if __name__ == '__main__':
     parser = argparse.ArgumentParser('Corr script looper')
     parser.add_argument(
-        '--z-corr', required=True,
+        '--z-corr', required=True, type=file_path('h5'),
         help='The correlation matrix that was used to create the explanations'
     )
     parser.add_argument(
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--outdir',
         help='Path to an output directory. Will be created if it non '
-             'existing. If not provided, outut files will be put in a '
+             'existing. If not provided, output files will be put in a '
              'directory called "output" in the "--base-path". If path '
              'starts with "s3:" upload to s3 instead and must then have the '
              'form "s3:<bucket>/<sub_dir>" where <bucket> must be specified '

--- a/depmap_analysis/scripts/gather_all_corr_stats.py
+++ b/depmap_analysis/scripts/gather_all_corr_stats.py
@@ -7,7 +7,8 @@ from datetime import datetime
 
 import pandas as pd
 
-from depmap_analysis.util.io_functions import pickle_open
+from depmap_analysis.util.io_functions import pickle_open, file_path, \
+    is_dir_path
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,15 @@ if __name__ == '__main__':
         help='The correlation matrix that was used to create the explanations'
     )
     parser.add_argument(
-        '--base-path', required=True,
+        '--reactome', type=file_path('pkl'),
+        help='A tuple or list of dicts. The first dict is expected to'
+             'contain mappings from UP IDs of genes to Reactome pathway IDs.'
+             'The second dict is expected to contain the reverse mapping '
+             '(i.e Reactome IDs to UP IDs). The third dict is expected to '
+             'contain mappings from Reactome IDs to their descriptions.'
+    )
+    parser.add_argument(
+        '--base-path', required=True, type=is_dir_path(),
         help='The path to the pickled explainer classes for each SD range.'
     )
     parser.add_argument(
@@ -76,10 +85,16 @@ if __name__ == '__main__':
     logger.info(f'Loading correlation file {args.z_corr}')
     if not dry:
         z_corr = pd.read_hdf(args.z_corr)
+        if args.reactome:
+            logger.info(f'Loading reactome file {args.reactome}')
+            reactome = pickle_open(args.reactome)
+        else:
+            reactome = None
     else:
         if not Path(args.z_corr).is_file():
             raise FileNotFoundError(f'{args.z_corr} was not found')
         z_corr = pd.DataFrame()
+        reactome = None
     # Create a global indexer to separate each figure
     indexer = count(0)
     for explainer_file in base_path.glob('*.pkl'):
@@ -92,7 +107,9 @@ if __name__ == '__main__':
             explainer = pickle_open(explainer_file)
             # Run stuff
             explainer.plot_corr_stats(outdir=explainer_out,
-                                      z_corr=z_corr, show_plot=False,
+                                      z_corr=z_corr,
+                                      reactome=reactome,
+                                      show_plot=False,
                                       max_proc=max_proc,
                                       index_counter=indexer,
                                       max_so_pairs_size=args.max_so_pairs,

--- a/depmap_analysis/util/statistics.py
+++ b/depmap_analysis/util/statistics.py
@@ -296,8 +296,9 @@ class DepMapExplainer:
                         # Reset pointer
                         fname.seek(0)
                         # Upload to s3
-                        _upload_to_s3(bytes_io_obj=fname, bucket=bucket,
-                                      key=key_base + '/' + name)
+                        _upload_bytes_io_to_s3(bytes_io_obj=fname,
+                                               bucket=bucket,
+                                               key=key_base + '/' + name)
 
                     # Show plot
                     if show_plot:
@@ -367,8 +368,8 @@ class DepMapExplainer:
             # Reset pointer
             fname.seek(0)
             # Upload to s3
-            _upload_to_s3(bytes_io_obj=fname, bucket=bucket,
-                          key=key_base + '/' + name)
+            _upload_bytes_io_to_s3(bytes_io_obj=fname, bucket=bucket,
+                                   key=key_base + '/' + name)
 
         # Show plot
         if show_plot:
@@ -378,12 +379,12 @@ class DepMapExplainer:
         plt.close(fig_index)
 
 
-def _upload_to_s3(bytes_io_obj, bucket, key):
+def _upload_bytes_io_to_s3(bytes_io_obj, bucket, key):
     """
 
     :param bytes_io_obj: BytesIO
     :param bucket: str
-    :param key: srt
+    :param key: str
     """
     bytes_io_obj.seek(0)  # Just in case
     s3 = get_s3_client(unsigned=False)

--- a/depmap_analysis/util/statistics.py
+++ b/depmap_analysis/util/statistics.py
@@ -328,8 +328,9 @@ class DepMapExplainer:
                     # Close figure
                     plt.close(fig_index)
                 else:
-                    logger.warning('Empty result for %s (%s) in range %s'
-                                   % (k, plot_type, sd))
+                    logger.warning(f'Empty result for {k} ({plot_type}) in '
+                                   f'range {sd} for graph type '
+                                   f'{self.script_settings["graph_type"]}')
 
     def plot_dists(self, outdir, z_corr=None, reactome=None,
                    show_plot=False, max_proc=None, index_counter=None,
@@ -399,8 +400,11 @@ class DepMapExplainer:
                  color='b', alpha=0.3)
         plt.hist(all_ind['avg_x_corrs'], bins='auto', density=True,
                  color='r', alpha=0.3)
-        plt.hist(all_ind['reactome_avg_corrs'], bins='auto', density=True,
-                 color='g', alpha=0.3)
+        legend = ['A-X-B for all X', 'A-X-B for X in network']
+        if len(all_ind['reactome_avg_corrs']):
+            plt.hist(all_ind['reactome_avg_corrs'], bins='auto',
+                     density=True, color='g', alpha=0.3)
+            legend.append('A-X-B for X in reactome path')
 
         sd_str = f'{self.sd_range[0]} - {self.sd_range[1]} SD' \
             if self.sd_range[1] else f'{self.sd_range[0]}+ SD'
@@ -409,8 +413,7 @@ class DepMapExplainer:
         plt.title(title)
         plt.ylabel('Norm. Density')
         plt.xlabel('mean(abs(corr(a,x)), abs(corr(x,b))) (SD)')
-        plt.legend(['A-X-B for all X', 'A-X-B for X in network',
-                    'A-X-B for X in reactome path'])
+        plt.legend()
         name = '%s_%s_axb_hist_comparison.pdf' % \
                (sd_str, self.script_settings['graph_type'])
 

--- a/depmap_analysis/util/statistics.py
+++ b/depmap_analysis/util/statistics.py
@@ -193,7 +193,7 @@ class DepMapExplainer:
             the Reactome IDs to their descriptions.
         max_so_pairs_size : int
             The maximum number of correlation pairs to process. If the
-            number of eligble pairs is larger than this number, a random
+            number of eligible pairs is larger than this number, a random
             sample of max_so_pairs_size is used. Default: 10 000. If the
             number of pairs to check is smaller than 10 000, no sampling is
             done.

--- a/depmap_analysis/util/statistics.py
+++ b/depmap_analysis/util/statistics.py
@@ -270,7 +270,8 @@ class DepMapExplainer:
                                            'all_reactome_corrs',
                                            'reactome_avg_corrs']):
                 if len(v[plot_type]) > 0:
-                    name = '%s_%s.pdf' % (plot_type, k)
+                    name = '%s_%s_%s.pdf' % \
+                           (plot_type, k, self.script_settings['graph_type'])
                     if od is None:
                         fname = BytesIO()
                     else:
@@ -283,10 +284,11 @@ class DepMapExplainer:
                         else int(f'{n}{m}')
                     plt.figure(fig_index)
                     plt.hist(x=data, bins='auto')
-                    plt.title('%s %s; %s' %
-                              (plot_type.replace('_', ' ').capitalize(),
-                               k.replace('_', ' '),
-                               sd))
+                    title = '%s %s; %s (%s)' % \
+                            (plot_type.replace('_', ' ').capitalize(),
+                             k.replace('_', ' '), sd,
+                             self.script_settings['graph_type'])
+                    plt.title(title)
                     plt.xlabel('combined z-score')
                     plt.ylabel('count')
 
@@ -351,12 +353,15 @@ class DepMapExplainer:
 
         sd_str = f'{self.sd_range[0]} - {self.sd_range[1]} SD' \
             if self.sd_range[1] else f'{self.sd_range[0]}+ SD'
-        plt.title('A-B corrs %s, indirect paths only' % sd_str)
+        title = 'avg X corrs %s (%s)' % (sd_str,
+                                         self.script_settings['graph_type'])
+        plt.title(title)
         plt.ylabel('Norm. Density')
         plt.xlabel('mean(abs(corr(a,x)), abs(corr(x,b))) (SD)')
         plt.legend(['A-X-B for all X', 'A-X-B for X in network',
                     'A-X-B for X in reactome path'])
-        name = '%s_axb_hist_comparison.pdf' % sd_str
+        name = '%s_%s_axb_hist_comparison.pdf' % \
+               (sd_str, self.script_settings['graph_type'])
 
         # Save to file or ByteIO and S3
         if od is None:


### PR DESCRIPTION
This PR adds two new updates:

- The random sampling of genes to form pairs to explain in the depmap script. This creates an estimate of how often pairs of genes picked at random can be explained.
- The integration of using genes common to reactome pathways as another comparison for the distribution of correlations between A-X and X-B.

Additionally, a lot of unused code was removed from some files.