### PR TITLE
MTI mesh ids

### DIFF
--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -293,6 +293,7 @@ def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict, set_weights
 
 
 def sif_dump_df_to_digraph(df, strat_ev_dict, belief_dict,
+                           mesh_id_dict,
                            graph_type='digraph',
                            include_entity_hierarchies=True,
                            verbosity=0):
@@ -311,6 +312,9 @@ def sif_dump_df_to_digraph(df, strat_ev_dict, belief_dict,
         The file path to a pickled dict or a dict object keyed by statement
         hash containing the stratified evidence count per statement. The
         hashes should correspond to the hashes in the loaded dataframe.
+    mesh_id_dict : dict
+        A dict object mapping statement hashes to all mesh ids sharing a 
+        common PMID
     graph_type : str
         Return type for the returned graph. Currently supports:
             - 'digraph': IndraNet(nx.DiGraph) (Default)
@@ -331,7 +335,7 @@ def sif_dump_df_to_digraph(df, strat_ev_dict, belief_dict,
                          ' %s' % (graph_type, graph_options))
     graph_type = graph_type.lower()
 
-    sif_df = sif_dump_df_merger(df, strat_ev_dict, belief_dict,
+    sif_df = sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict,
                                 verbosity=verbosity)
 
     # Map ns:id to node name

--- a/depmap_analysis/util/aws.py
+++ b/depmap_analysis/util/aws.py
@@ -16,7 +16,7 @@ NEW_NETS_PREFIX = NETS_PREFIX + '/new'
 
 
 def get_latest_sif_s3():
-    necc_files = ['belief', 'sif', 'src_counts']
+    necc_files = ['belief', 'sif', 'src_counts', 'mesh_ids']
     s3 = get_s3_client(unsigned=False)
     tree = get_s3_file_tree(s3, bucket=DUMPS_BUCKET, prefix=DUMPS_PREFIX,
                             with_dt=True)
@@ -41,7 +41,9 @@ def get_latest_sif_s3():
                               bucket=DUMPS_BUCKET)
     bd = read_json_from_s3(s3, key=necc_keys['belief'],
                            bucket=DUMPS_BUCKET)
-    return df, sev, bd
+    mid = load_pickle_from_s3(s3, key=necc_keys['mesh_ids'],
+                              bucket=DUMPS_BUCKET)
+    return df, sev, bd, mid
 
 
 def load_pickled_net_from_s3(name):

--- a/indra_depmap_service/util.py
+++ b/indra_depmap_service/util.py
@@ -268,10 +268,16 @@ def dump_query_result_to_s3(filename, json_obj, get_url=False):
 def dump_new_nets(mdg=None, dg=None, sg=None, spbg=None, dump_to_s3=False,
                   verbosity=0):
     """Main script function for dumping new networks from latest db dumps"""
-    df, sev, bd = get_latest_sif_s3()
+    df, sev, bd, mid = get_latest_sif_s3()
+
+    mid_dict = dict()
+    for pair in mid:
+        mid_dict.setdefault(pair[0], []).append(pair[1])
+
     options = {'df': df,
                'belief_dict': bd,
                'strat_ev_dict': sev,
+               'mesh_id_dict' : mid_dict,
                'include_entity_hierarchies': True,
                'verbosity': verbosity}
 


### PR DESCRIPTION
This PR adds a new column to the DataFrame built inside `sif_dump_df_merger`. For each row with a statement hash, the column contains a list of Mesh IDs parsed from MTI outputs that share common PMID with that statement. The data are read from S3 as a pickled list and then transformed into a dict object used for filling the column.