### PR TITLE
Make mesh id dict optional

### DIFF
--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -84,10 +84,6 @@ def _curated_func(ev_dict):
         (False if all(s.lower() in READERS for s in ev_dict) else True)
 
 
-# Initialize bio ontology before use
-bio_ontology.initialize()
-
-
 def _weight_from_belief(belief):
     """Map belief score 'belief' to weight. If the calculation goes below
     precision, return longfloat precision insted to avoid making the

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -357,7 +357,7 @@ def sif_dump_df_to_digraph(df, strat_ev_dict, belief_dict,
             weight_mapping=_weight_mapping
         )
         signed_node_graph = signed_edges_to_signed_nodes(
-            graph=signed_edge_graph, copy_edge_data={'weight'})
+            graph=signed_edge_graph, copy_edge_data={'weight', 'belief'})
         signed_edge_graph.graph['node_by_ns_id'] = ns_id_to_nodename
         signed_node_graph.graph['node_by_ns_id'] = ns_id_to_nodename
         return signed_edge_graph, signed_node_graph

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -17,7 +17,6 @@ from indra.assemblers.indranet import IndraNet
 from indra.databases import get_identifiers_url
 from indra.assemblers.pybel import PybelAssembler
 from indra.assemblers.pybel.assembler import belgraph_to_signed_graph
-from indra_reading.readers import get_reader_classes
 from indra.explanation.model_checker.model_checker import \
     signed_edges_to_signed_nodes
 from depmap_analysis.util.aws import get_latest_pa_stmt_dump
@@ -40,8 +39,8 @@ REVERSE_SIGN = {INT_PLUS: INT_MINUS, INT_MINUS: INT_PLUS,
                 '+': '-', '-': '+',
                 'plus': 'minus', 'minus': 'plus'}
 
-READERS = set([rc.name.lower() for rc in get_reader_classes()])
-READERS.update(['medscan', 'rlimsp'])
+READERS = set(['reach', 'trips', 'isi', 'sparser', 'medscan', 'rlimsp',
+                'eidos', 'cwms', 'geneways', 'tees', 'hume', 'sofia'])
 
 
 def _get_smallest_belief_prior():
@@ -80,7 +79,7 @@ def gilda_pinger():
 def _curated_func(ev_dict):
     """Return False if no source dict exists, or if all sources are
     readers, otherwise return True."""
-    return False if not ev_dict else \
+    return False if not ev_dict or not isinstance(ev_dict, dict) else \
         (False if all(s.lower() in READERS for s in ev_dict) else True)
 
 

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -143,7 +143,7 @@ def _english_from_agents_type(agA_name, agB_name, stmt_type):
     return EnglishAssembler([stmt]).make_model()
 
 
-def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict, set_weights=True,
+def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict=None, set_weights=True,
                        verbosity=0):
     """Merge the sif dump df with the provided dictionaries
 
@@ -204,7 +204,7 @@ def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict, set_weights
     #   belief score from provided dict
     #   stratified evidence count by source
     #   english string from mock statements
-    #   mesh_id mapped by provided dict
+    #   mesh_id mapped by dict (if provided)
     # Extend df with famplex rows
     # 'stmt_hash' must exist as column in the input dataframe for merge to work
     # Preserve all rows in merged_df, so do left join:
@@ -243,18 +243,19 @@ def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict, set_weights
         on='stmt_hash'
     )
 
-    hashes = []
-    mesh_ids = []
-    for k, v in mesh_id_dict.items():
-        hashes.append(int(k))
-        mesh_ids.append(v)
+    if mesh_id_dict is not None:
+        hashes = []
+        mesh_ids = []
+        for k, v in mesh_id_dict.items():
+            hashes.append(int(k))
+            mesh_ids.append(v)
 
-    merged_df = merged_df.merge(
-        right=pd.DataFrame(data={'stmt_hash': hashes,
-                                 'mesh_ids': mesh_ids}),
-        how='left',
-        on='stmt_hash'
-    )
+        merged_df = merged_df.merge(
+            right=pd.DataFrame(data={'stmt_hash': hashes,
+                                    'mesh_ids': mesh_ids}),
+            how='left',
+            on='stmt_hash'
+        )
 
     # Check for missing hashes
     if merged_df['source_counts'].isna().sum() > 0:
@@ -293,7 +294,7 @@ def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict, set_weights
 
 
 def sif_dump_df_to_digraph(df, strat_ev_dict, belief_dict,
-                           mesh_id_dict,
+                           mesh_id_dict=None,
                            graph_type='digraph',
                            include_entity_hierarchies=True,
                            verbosity=0):

--- a/depmap_analysis/util/aws.py
+++ b/depmap_analysis/util/aws.py
@@ -9,6 +9,7 @@ from indra_db.managers.dump_manager import Belief, Sif, StatementHashMeshId,\
     SourceCount
 
 dumpers = [Belief, Sif, SourceCount]
+dumpers_alt_name = {SourceCount.name: 'src_counts'}
 
 logger = logging.getLogger(__name__)
 
@@ -32,13 +33,16 @@ def get_latest_sif_s3(get_mesh_ids=False):
     # Sort newest first
     keys.sort(key=lambda t: t[1], reverse=True)
     # Get keys of those pickles
-    keys_in_latest_dir = [k[0] for k in keys if
-                          any(nfl in k[0] for nfl in necc_files)]
+    keys_in_latest_dir = \
+        [k[0] for k in keys if
+         any(nfl in k[0] for nfl in necc_files) or
+         any(dumpers_alt_name.get(nfl, 'null') in k[0] for nfl in necc_files)]
     # Map key to resource
     necc_keys = {}
     for n in necc_files:
         for k in keys_in_latest_dir:
-            if n in k:
+            # check name then alt name
+            if n in k or dumpers_alt_name.get(n, 'null') in k:
                 # Save and continue to next file in necc_files
                 necc_keys[n] = k
                 break

--- a/depmap_analysis/util/aws.py
+++ b/depmap_analysis/util/aws.py
@@ -15,8 +15,10 @@ NETS_PREFIX = 'indra_db_files'
 NEW_NETS_PREFIX = NETS_PREFIX + '/new'
 
 
-def get_latest_sif_s3():
-    necc_files = ['belief', 'sif', 'src_counts', 'mesh_ids']
+def get_latest_sif_s3(get_mesh_ids=False):
+    necc_files = ['belief', 'sif', 'src_counts']
+    if get_mesh_ids:
+        necc_files.append('mesh_ids')
     s3 = get_s3_client(unsigned=False)
     tree = get_s3_file_tree(s3, bucket=DUMPS_BUCKET, prefix=DUMPS_PREFIX,
                             with_dt=True)
@@ -41,10 +43,12 @@ def get_latest_sif_s3():
                               bucket=DUMPS_BUCKET)
     bd = read_json_from_s3(s3, key=necc_keys['belief'],
                            bucket=DUMPS_BUCKET)
-    mid = load_pickle_from_s3(s3, key=necc_keys['mesh_ids'],
-                              bucket=DUMPS_BUCKET)
-    return df, sev, bd, mid
+    if get_mesh_ids:
+        mid = load_pickle_from_s3(s3, key=necc_keys['mesh_ids'],
+                                bucket=DUMPS_BUCKET)
+        return df, sev, bd, mid
 
+    return df, sev, bd
 
 def load_pickled_net_from_s3(name):
     s3_cli = get_s3_client(False)

--- a/indra_depmap_service/util.py
+++ b/indra_depmap_service/util.py
@@ -266,7 +266,7 @@ def dump_query_result_to_s3(filename, json_obj, get_url=False):
     return None
 
 
-def dump_new_nets(mdg=None, dg=None, sg=None, spbg=None, dump_to_s3=False,
+def dump_new_nets(mdg=False, dg=False, sg=False, spbg=False, dump_to_s3=False,
                   verbosity=0, add_mesh_ids=False):
     """Main script function for dumping new networks from latest db dumps"""
     options = dict()
@@ -280,11 +280,9 @@ def dump_new_nets(mdg=None, dg=None, sg=None, spbg=None, dump_to_s3=False,
     else:
         df, sev, bd = get_latest_sif_s3()
 
-    options = options.update({'df': df,
-                              'belief_dict': bd,
-                              'strat_ev_dict': sev,
-                              'include_entity_hierarchies': True,
-                              'verbosity': verbosity})
+    options.update({'df': df, 'belief_dict': bd, 'strat_ev_dict': sev,
+                    'include_entity_hierarchies': True,
+                    'verbosity': verbosity})
 
     if mdg:
         network = nf.sif_dump_df_to_digraph(graph_type='multi', **options)

--- a/indra_depmap_service/util.py
+++ b/indra_depmap_service/util.py
@@ -215,7 +215,7 @@ def load_indra_graph(dir_graph_path, multi_digraph_path=None,
     indra_signed_edge_graph = nx.MultiDiGraph()
     indra_signed_node_graph = nx.DiGraph()
 
-    if update:
+    if update:  # Todo: Download from db dumps instead
         df = make_dataframe(True, load_db_content(True, NS_LIST))
         options = {'df': df,
                    'belief_dict': belief_dict,

--- a/indra_depmap_service/util.py
+++ b/indra_depmap_service/util.py
@@ -12,7 +12,6 @@ import networkx as nx
 from fnvhash import fnv1a_32
 
 from indra_db.client.readonly.query import FromMeshIds
-from indra_db.config import CONFIG_EXISTS
 from indra_db.util.dump_sif import load_db_content, make_dataframe, NS_LIST
 from indra.statements import get_all_descendants, Activation, Inhibition, \
     IncreaseAmount, DecreaseAmount, AddModification, RemoveModification, \
@@ -318,10 +317,7 @@ def dump_new_nets(mdg=None, dg=None, sg=None, spbg=None, dump_to_s3=False,
 
 def find_related_hashes(mesh_ids):
     q = FromMeshIds(mesh_ids)
-    if CONFIG_EXISTS:
-        result = q.get_hashes()
-    else:
-        result = q.rest_get('hashes')
+    result = q.get_hashes()
     return result.json().get('results', [])
 
 

--- a/indra_depmap_service/util.py
+++ b/indra_depmap_service/util.py
@@ -11,6 +11,8 @@ from datetime import datetime
 import networkx as nx
 from fnvhash import fnv1a_32
 
+from indra_db.client.readonly.query import FromMeshIds
+from indra_db.config import CONFIG_EXISTS
 from indra_db.util.dump_sif import load_db_content, make_dataframe, NS_LIST
 from indra.statements import get_all_descendants, Activation, Inhibition, \
     IncreaseAmount, DecreaseAmount, AddModification, RemoveModification, \
@@ -312,6 +314,15 @@ def dump_new_nets(mdg=None, dg=None, sg=None, spbg=None, dump_to_s3=False,
         if dump_to_s3:
             dump_pickle_to_s3(INDRA_SNG, pb_sng, prefix=NEW_NETS_PREFIX)
             dump_pickle_to_s3(INDRA_SEG, pb_seg, prefix=NEW_NETS_PREFIX)
+
+
+def find_related_hashes(mesh_ids):
+    q = FromMeshIds(mesh_ids)
+    if CONFIG_EXISTS:
+        result = q.get_hashes()
+    else:
+        result = q.rest_get('hashes')
+    return result.json().get('results', [])
 
 
 if __name__ == '__main__':

--- a/indra_depmap_service/util.py
+++ b/indra_depmap_service/util.py
@@ -266,20 +266,24 @@ def dump_query_result_to_s3(filename, json_obj, get_url=False):
 
 
 def dump_new_nets(mdg=None, dg=None, sg=None, spbg=None, dump_to_s3=False,
-                  verbosity=0):
+                  verbosity=0, add_mesh_ids=False):
     """Main script function for dumping new networks from latest db dumps"""
-    df, sev, bd, mid = get_latest_sif_s3()
+    options = dict()
 
-    mid_dict = dict()
-    for pair in mid:
-        mid_dict.setdefault(pair[0], []).append(pair[1])
+    if add_mesh_ids:
+        df, sev, bd, mid = get_latest_sif_s3(get_mesh_ids=True)
+        mid_dict = dict()
+        for pair in mid:
+            mid_dict.setdefault(pair[0], []).append(pair[1])
+        options['mesh_id_dict'] = mid_dict
+    else:
+        df, sev, bd = get_latest_sif_s3()
 
-    options = {'df': df,
-               'belief_dict': bd,
-               'strat_ev_dict': sev,
-               'mesh_id_dict' : mid_dict,
-               'include_entity_hierarchies': True,
-               'verbosity': verbosity}
+    options = options.update({'df': df,
+                              'belief_dict': bd,
+                              'strat_ev_dict': sev,
+                              'include_entity_hierarchies': True,
+                              'verbosity': verbosity})
 
     if mdg:
         network = nf.sif_dump_df_to_digraph(graph_type='multi', **options)


### PR DESCRIPTION
This PR disables loading the _[(statement hash, mesh_ids),...]_-like pickled list and adding data from it to a network by default. It, however, makes it possible to do it manually using special function parameters