### PR TITLE
Network search using mesh ids

### DIFF
--- a/depmap_analysis/network_functions/indra_network.py
+++ b/depmap_analysis/network_functions/indra_network.py
@@ -1586,7 +1586,7 @@ def list_all_hashes(ksp_results):
 def get_subgraph_from_mesh_ids(indra_graph, mesh_ids):
     """Builds a subgraph with edges related to supplied mesh_ids"""
     related_hashes = find_related_hashes(mesh_ids)
-    subgraph = nx.DiGraph
+    subgraph = nx.DiGraph()
     for e in indra_graph.edges:
         edge_hashes = set(indra_graph.edges[e]['statements'])
         if edge_hashes & related_hashes:

--- a/depmap_analysis/network_functions/indra_network.py
+++ b/depmap_analysis/network_functions/indra_network.py
@@ -1593,7 +1593,7 @@ def get_subgraph_from_mesh_ids(indra_graph, mesh_ids):
     related_hashes = find_related_hashes(mesh_ids)
     subgraph = nx.DiGraph()
     for e in indra_graph.edges:
-        edge_hashes = set(indra_graph.edges[e]['statements'])
+        edge_hashes = set(indra_graph.edges[e]['statements'].keys())
         if edge_hashes & related_hashes:
             subgraph.add_edge(e)
     return subgraph

--- a/depmap_analysis/network_functions/indra_network.py
+++ b/depmap_analysis/network_functions/indra_network.py
@@ -8,6 +8,7 @@ import requests
 import networkx as nx
 from networkx import NodeNotFound, NetworkXNoPath
 
+from indra_depmap_service.util import find_related_hashes
 from indra.config import CONFIG_DICT
 from indra.databases import get_identifiers_url
 from indra.assemblers.indranet.net import default_sign_dict
@@ -1570,3 +1571,14 @@ def list_all_hashes(ksp_results):
                     hash_set.update([item['stmt_hash'] for item in
                                      meta_list])
     return list(hash_set)
+
+
+def get_subgraph_from_mesh_ids(indra_graph, mesh_ids):
+    """Builds a subgraph with edges related to supplied mesh_ids"""
+    related_hashes = find_related_hashes(mesh_ids)
+    subgraph = nx.DiGraph
+    for e in indra_graph.edges:
+        edge_hashes = set(indra_graph.edges[e]['statements'])
+        if edge_hashes & related_hashes:
+            subgraph.add_edge(e)
+    return subgraph

--- a/depmap_analysis/network_functions/indra_network.py
+++ b/depmap_analysis/network_functions/indra_network.py
@@ -601,7 +601,12 @@ class IndraNetwork:
                             if options['weight'] else '')
             if options['sign'] is None:
                 # Do unsigned path search
-                paths = shortest_simple_paths(self.nx_dir_graph_repr,
+                if options['mesh_ids'] is None:
+                    search_graph = self.nx_dir_graph_repr
+                else:
+                    search_graph = get_subgraph_from_mesh_ids(
+                        self.nx_dir_graph_repr, options['mesh_ids'])
+                paths = shortest_simple_paths(search_graph,
                                                  source, target,
                                                  options['weight'],
                                                  **blacklist_options)
@@ -620,8 +625,13 @@ class IndraNetwork:
                 signed_blacklisted_nodes = []
                 for n in options.get('node_blacklist', []):
                     signed_blacklisted_nodes += [(n, INT_PLUS), (n, INT_MINUS)]
+                if options['mesh_ids'] is None:
+                    search_graph = self.sign_node_graph_repr
+                else:
+                    search_graph = get_subgraph_from_mesh_ids(
+                        self.sign_node_graph_repr, options['mesh_ids'])
                 paths = shortest_simple_paths(
-                    self.sign_node_graph_repr, subj, obj, options['weight'],
+                    search_graph, subj, obj, options['weight'],
                     ignore_nodes=signed_blacklisted_nodes)
 
             return self._loop_paths(source=subj, target=obj, paths_gen=paths,

--- a/depmap_analysis/network_functions/indra_network.py
+++ b/depmap_analysis/network_functions/indra_network.py
@@ -1301,23 +1301,23 @@ class IndraNetwork:
             i = 0
             try:
                 stmt_edge = self.signed_edges[(s, o, sign)][
-                    'statements'][index]
+                    'statements'][i]
                 while stmt_edge:
                     yield stmt_edge
                     i += 1
                     stmt_edge = self.signed_edges[(s, o, sign)][
-                        'statements'][index]
+                        'statements'][i]
             except IndexError:
                 return
 
         else:
             i = 0
             try:
-                stmt_edge = self.dir_edges[(s, o)]['statements'][index]
+                stmt_edge = self.dir_edges[(s, o)]['statements'][i]
                 while stmt_edge:
                     yield stmt_edge
                     i += 1
-                    stmt_edge = self.dir_edges[(s, o)]['statements'][index]
+                    stmt_edge = self.dir_edges[(s, o)]['statements'][i]
             except IndexError:
                 return
 


### PR DESCRIPTION
This PR optimizes the path finding in `IndraNetwork.find_shortest_paths()`. When `mesh_ids` list is provided as an argument, the method finds statement hashes related to those mesh ids and builds a subgraph containing only edges with those hashes. That subgraph is then used for path finding instead of the whole graph.