### PR TITLE
Hash to edge mapping

### DIFF
--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -513,10 +513,28 @@ def db_dump_to_pybel_sg(stmts_list=None):
         propagate_annotations=True
     )
 
+    # Map hashes to edges
+    logger.info('Getting hash to signed edge mapping')
+    seg_hash_edge_dict = {}
+    for edge in pb_signed_edge_graph.edges:
+        if pb_signed_edge_graph.edges[edge].get('stmt_hash'):
+            seg_hash_edge_dict[
+                pb_signed_edge_graph.edges[edge]['stmt_hash']] = edge
+    pb_signed_edge_graph.graph['edge_by_hash'] = seg_hash_edge_dict
+
     # Get the signed node graph
     logger.info('Getting a signed node graph from signed edge graph')
     pb_signed_node_graph = signed_edges_to_signed_nodes(
         pb_signed_edge_graph, copy_edge_data=True)
+
+    # Map hashes to edges for signed nodes
+    logger.info('Getting hash to edge mapping')
+    sng_hash_edge_dict = {}
+    for edge in pb_signed_node_graph.edges:
+        if pb_signed_node_graph.edges[edge].get('stmt_hash'):
+            sng_hash_edge_dict[
+                pb_signed_node_graph.edges[edge]['stmt_hash']] = edge
+    pb_signed_node_graph.graph['edge_by_hash'] = sng_hash_edge_dict
 
     logger.info('Done assembling signed edge and signed node PyBEL graphs')
     return pb_signed_edge_graph, pb_signed_node_graph

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -138,8 +138,8 @@ def _english_from_agents_type(agA_name, agB_name, stmt_type):
     return EnglishAssembler([stmt]).make_model()
 
 
-def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict=None, set_weights=True,
-                       verbosity=0):
+def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict=None,
+                       set_weights=True, verbosity=0):
     """Merge the sif dump df with the provided dictionaries
 
     Parameters

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -84,7 +84,7 @@ def _curated_func(ev_dict):
 
 def _weight_from_belief(belief):
     """Map belief score 'belief' to weight. If the calculation goes below
-    precision, return longfloat precision insted to avoid making the
+    precision, return longfloat precision instead to avoid making the
     weight zero."""
     return np.max([NP_PRECISION, -np.log(belief, dtype=np.longfloat)])
 
@@ -244,7 +244,7 @@ def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict=None,
 
         merged_df = merged_df.merge(
             right=pd.DataFrame(data={'stmt_hash': hashes,
-                                    'mesh_ids': mesh_ids}),
+                                     'mesh_ids': mesh_ids}),
             how='left',
             on='stmt_hash'
         )
@@ -388,7 +388,7 @@ def sif_dump_df_to_digraph(df, strat_ev_dict, belief_dict,
                                                      'digraph'):
         from depmap_analysis.network_functions.famplex_functions import \
             get_all_entities
-        logger.info('Fetching entity hierarchy relationsships')
+        logger.info('Fetching entity hierarchy relationships')
         full_entity_list = get_all_entities()
         logger.info('Adding entity hierarchy manager as graph attribute')
         node_by_uri = {uri: _id for (ns, _id, uri) in full_entity_list}
@@ -666,7 +666,7 @@ def ag_belief_score(belief_list):
 
 
 def ns_id_from_name(name, gilda_retry=False):
-    """Query the groudning service for the most likely ns:id pair for name"""
+    """Query the grounding service for the most likely ns:id pair for name"""
     global GILDA_TIMEOUT
     if gilda_retry and GILDA_TIMEOUT and gilda_pinger():
         logger.info('GILDA is responding again!')
@@ -684,7 +684,7 @@ def ns_id_from_name(name, gilda_retry=False):
                                res.status_code)
         except IndexError:
             logger.info('No grounding exists for %s' % name)
-        except ConnectionError as err2:
+        except ConnectionError:
             logger.warning('GILDA has timed out, ignoring future requests')
             GILDA_TIMEOUT = True
     else:

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -21,7 +21,6 @@ from indra.explanation.model_checker.model_checker import \
     signed_edges_to_signed_nodes
 from depmap_analysis.util.aws import get_latest_pa_stmt_dump
 from depmap_analysis.util.io_functions import file_opener
-import depmap_analysis.network_functions.famplex_functions as fplx_fcns
 
 logger = logging.getLogger(__name__)
 
@@ -387,8 +386,10 @@ def sif_dump_df_to_digraph(df, strat_ev_dict, belief_dict,
     # Add hierarchy relations to graph (not applicable for signed graphs)
     if include_entity_hierarchies and graph_type in ('multidigraph',
                                                      'digraph'):
+        from depmap_analysis.network_functions.famplex_functions import \
+            get_all_entities
         logger.info('Fetching entity hierarchy relationsships')
-        full_entity_list = fplx_fcns.get_all_entities()
+        full_entity_list = get_all_entities()
         logger.info('Adding entity hierarchy manager as graph attribute')
         node_by_uri = {uri: _id for (ns, _id, uri) in full_entity_list}
         added_pairs = set()  # Save (A, B, URI)

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -20,7 +20,7 @@ from indra.assemblers.pybel.assembler import belgraph_to_signed_graph
 from indra.explanation.model_checker.model_checker import \
     signed_edges_to_signed_nodes
 from depmap_analysis.util.aws import get_latest_pa_stmt_dump
-from depmap_analysis.util.io_functions import pickle_open
+from depmap_analysis.util.io_functions import file_opener
 import depmap_analysis.network_functions.famplex_functions as fplx_fcns
 
 logger = logging.getLogger(__name__)
@@ -171,14 +171,12 @@ def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict=None, set_we
     sed = None
 
     if isinstance(df, str):
-        if df.endswith('.pkl'):
-            merged_df = pickle_open(df)
-        elif df.endswith('.csv'):
+        if df.endswith('.csv'):
             logger.info(f'Loading csv file {df}')
             merged_df = pd.read_csv(df)
             logger.info('Finished loading csv file')
         else:
-            raise ValueError('Path to DataFrame must be a .pkl or .csv file')
+            merged_df = file_opener(df)
     else:
         merged_df = df
 
@@ -186,12 +184,12 @@ def sif_dump_df_merger(df, strat_ev_dict, belief_dict, mesh_id_dict=None, set_we
         merged_df.rename(columns={'hash': 'stmt_hash'}, inplace=True)
 
     if isinstance(belief_dict, str):
-        belief_dict = pickle_open(belief_dict)
+        belief_dict = file_opener(belief_dict)
     elif isinstance(belief_dict, dict):
         belief_dict = belief_dict
 
     if isinstance(strat_ev_dict, str):
-        sed = pickle_open(strat_ev_dict)
+        sed = file_opener(strat_ev_dict)
     elif isinstance(strat_ev_dict, dict):
         sed = strat_ev_dict
 

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -16,7 +16,8 @@ sif = {'agA_name': ['nameX1', 'nameX2'], 'agA_ns': ['nsX1', 'nsX2'],
 def test_sif_df():
     sif_df = pd.DataFrame(sif)
     idg = sif_dump_df_to_digraph(df=sif_df, strat_ev_dict=src,
-                                 belief_dict=bd, graph_type='digraph')
+                                 belief_dict=bd, graph_type='digraph',
+                                 include_entity_hierarchies=False)
     assert idg.graph.get('edge_by_hash')
     assert idg.graph['edge_by_hash'][1234657890] == ('nameX1', 'nameY1')
     assert idg.graph['edge_by_hash'][9876543210] == ('nameX2', 'nameY2')

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from depmap_analysis.network_functions.net_functions import \
+    sif_dump_df_to_digraph
+
+# Add input
+bd = {}
+src = {}
+sif = {}
+
+
+def test_sif_df():
+    sif_df = pd.DataFrame(sif)
+    idg = sif_dump_df_to_digraph(df=sif_df, strat_ev_dict=src,
+                                 belief_dict=bd, graph_type='digraph')
+    assert idg.graph.get('edge_by_hash')

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -3,9 +3,14 @@ from depmap_analysis.network_functions.net_functions import \
     sif_dump_df_to_digraph
 
 # Add input
-bd = {}
-src = {}
-sif = {}
+hashes = [1234657890, 9876543210]
+bd = {1234657890: 0.685, 9876543210: 0.95}
+src = {1234657890: {'srcA': 2, 'srcB': 5}, 9876543210: {'srcA': 5, 'srcB': 8}}
+sif = {'agA_name': ['nameX1', 'nameX2'], 'agA_ns': ['nsX1', 'nsX2'],
+       'agA_id': ['idX1', 'idX2'], 'agB_name': ['nameY1', 'nameY2'],
+       'agB_ns': ['nsY1', 'nsY2'], 'agB_id': ['idY1', 'idY2'],
+       'stmt_type': ['Activation', 'Complex'], 'evidence_count': [7, 13],
+       'stmt_hash': hashes}
 
 
 def test_sif_df():
@@ -13,3 +18,8 @@ def test_sif_df():
     idg = sif_dump_df_to_digraph(df=sif_df, strat_ev_dict=src,
                                  belief_dict=bd, graph_type='digraph')
     assert idg.graph.get('edge_by_hash')
+    assert idg.graph['edge_by_hash'][1234657890] == ('nameX1', 'nameY1')
+    assert idg.graph['edge_by_hash'][9876543210] == ('nameX2', 'nameY2')
+    assert idg.edges.get(('nameX1', 'nameY1'))
+    assert idg.edges[('nameX1', 'nameY1')]['statements'][0]['stmt_hash'] == \
+           1234657890

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -21,5 +21,6 @@ def test_sif_df():
     assert idg.graph['edge_by_hash'][1234657890] == ('nameX1', 'nameY1')
     assert idg.graph['edge_by_hash'][9876543210] == ('nameX2', 'nameY2')
     assert idg.edges.get(('nameX1', 'nameY1'))
+    assert isinstance(idg.edges[('nameX1', 'nameY1')]['statements'], list)
     assert idg.edges[('nameX1', 'nameY1')]['statements'][0]['stmt_hash'] == \
            1234657890

--- a/depmap_analysis/util/io_functions.py
+++ b/depmap_analysis/util/io_functions.py
@@ -11,6 +11,27 @@ import numpy as np
 logger = logging.getLogger('dnf utils')
 
 
+def file_opener(fname):
+    """Open file based on file extension
+
+    Parameters
+    ----------
+    fname : str
+        The filename
+
+    Returns
+    -------
+    object
+        Object stored in file fname
+    """
+    if fname.endswith('pkl'):
+        return pickle_open(fname)
+    elif fname.endswith('json'):
+        return json_open(fname)
+    else:
+        raise ValueError(f'Unknown file extension for file {fname}')
+
+
 def dump_it_to_pickle(fname, pyobj):
     """Save pyobj to fname as pickle"""
     logger.info('Dumping to pickle file %s' % fname)


### PR DESCRIPTION
This PR adds statement hash to edge mappings to the a graphs as part of the graph attributes. The dictionary is accessible as `my_graph.graph['edge_by_hash']`.

The mapping is either generated directly from the sif data frame (undigned graphs) or from the graph itself (signed graphs).

A wrapper function determining which file loader to call is also added.