### PR TITLE
Update NS_LIST

### DIFF
--- a/indra_depmap_service/api.py
+++ b/indra_depmap_service/api.py
@@ -7,7 +7,7 @@ import requests
 from flask import Flask, request, abort, Response, render_template, jsonify, \
     session, url_for
 
-from indra_db.util.dump_sif import NS_PRIORITY_LIST as NS_LIST_
+from indra.statements.agent import default_ns_order as NS_LIST_
 from indra.config import CONFIG_DICT
 from indra.util.aws import get_s3_client
 from indralab_web_templates.path_templates import path_temps


### PR DESCRIPTION
This PR changes one thing: the source of the namespace list used for the network search. This PR should **only** be merged after the next full indra database preassembly is done, as the new sif dump will be generated from the namespace priority list `default_ns_order` found in `indra.statements.agent`.

See:
https://github.com/indralab/indra_db/blob/master/indra_db/util/dump_sif.py#L14
https://github.com/sorgerlab/indra/blob/master/indra/statements/agent.py#L15-L16