### PR TITLE
Fix truncation bug

### DIFF
--- a/depmap_analysis/network_functions/indra_network.py
+++ b/depmap_analysis/network_functions/indra_network.py
@@ -55,7 +55,7 @@ USER_OVERRIDE = False
 
 
 def _truncate(n):
-    return trunc(n * 100) / 100
+    return float(trunc(n * 100) / 100)
 
 
 class MissingParametersError(Exception):

--- a/depmap_analysis/network_functions/indra_network.py
+++ b/depmap_analysis/network_functions/indra_network.py
@@ -3,7 +3,7 @@ import logging
 from itertools import product
 from collections import defaultdict
 from time import time, gmtime, strftime
-from math import trunc
+from numpy import trunc
 
 import requests
 import networkx as nx


### PR DESCRIPTION
This PR resolves two issues:
- The truncation of numpy floats by `math.trunc` is not possible yet and has to be done with `numpy.trunc`: see numpy issue 13375
- An error where JSON dumping of numpy floats is not allowed (see [here](https://stackoverflow.com/questions/27050108/convert-numpy-type-to-python))