### PR TITLE
Drug post script analysis 

### DIFF
--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -16,13 +16,19 @@ def _src_count(succ_list: List[Tuple[str, List[str]]], src: List[str]):
 
 
 def _percent_in_tas_or_db_A(row):
-    count = _src_count(row.succ_a_st, ['tas', 'drugbank'])
-    return count / len(row.succ_a_st)
+    if len(row.succ_a_st):
+        count = _src_count(row.succ_a_st, ['tas', 'drugbank'])
+        return count / len(row.succ_a_st)
+    else:
+        return 0
 
 
 def _percent_in_tas_or_db_B(row):
-    count = _src_count(row.succ_b_st, ['tas', 'drugbank'])
-    return count / len(row.succ_b_st)
+    if len(row.succ_b_st):
+        count = _src_count(row.succ_b_st, ['tas', 'drugbank'])
+        return count / len(row.succ_b_st)
+    else:
+        return 0
 
 
 def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -11,22 +11,41 @@ from depmap_analysis.util.statistics import DepMapExplainer
 logger = logging.getLogger(__name__)
 
 
-def get_rankings(expl_df: DataFrame, sampl_size: int = None)\
-        -> Tuple[Dict[str, Counter], Dict[str, List[Tuple[int, int, float]]]]:
+def get_rankings(expl_df: DataFrame, stats_df: DataFrame,
+                 sampl_size: int = None) -> \
+        Tuple[Dict[str, Counter],
+              Dict[str, List[Tuple[int, int, float]]],
+              List[Tuple[str, str, float, float, int, int]]]:
     """Get the count of next nearest neighborhood
 
     Parameters
     ----------
     expl_df : DataFrame
         Explanation dataframe
+    stats_df : DataFrame
+        Statistics dataframe
     sampl_size : int
-        Sampling size.
+        Sampling size
 
     Returns
     -------
     dict
         A dict of Counters for each examined agent
     """
+    jaccard_ranks = [
+        (agA, agB, corr, len(ins)/len(uni), len(ins), len(uni))
+        for agA, agB, corr, expl_type, (ins, uni) in
+        expl_df[expl_df['expl type'] ==
+                'shared downstream'].itertuples(index=False) if agA != agB
+    ]
+
+    # agA, agB, z-score, agA_ns, agA_id, agB_ns, agB_id, not in graph,
+    # explained, shared downstream
+    for (agA, agB, corr, _, _, _, _, _, _, _) in \
+            stats_df[stats_df.explained == False].itertuples(index=False):
+        if agA != agB:
+            jaccard_ranks.append((agA, agB, corr, 0, 0, float('nan')))
+
     # Get the agents that have any shared downstream explanations
     all_agents_sampled = \
         set(expl_df[expl_df['expl type'] == 'shared downstream'].agA.values) |\
@@ -48,7 +67,7 @@ def get_rankings(expl_df: DataFrame, sampl_size: int = None)\
             jaccard_index[ag_name].append((len(ins), len(uni),
                                            len(ins)/len(uni)))
         nnn_counters[ag_name] = Counter(ll)
-    return nnn_counters, jaccard_index
+    return nnn_counters, jaccard_index, jaccard_ranks
 
 
 if __name__ == '__main__':
@@ -59,7 +78,7 @@ if __name__ == '__main__':
         sample_size = None
     drug_expl = file_opener(drug_file)
     assert isinstance(drug_expl, DepMapExplainer)
-    rankings, ji = get_rankings(drug_expl.expl_df)
+    rankings, ji, jr = get_rankings(drug_expl.expl_df, drug_expl.stats_df)
 
     # Sum up the counters to get a full counter
     overall_ranking = Counter()
@@ -75,7 +94,15 @@ if __name__ == '__main__':
                                 sum(li)/len(li),
                                 sum(lu)/len(lu)))
     jaccard_ranking.sort(key=lambda t: t[1], reverse=True)
-    jaccard_df = DataFrame(
+    jaccard_df_per_drug = DataFrame(
         data=jaccard_ranking,
         columns=['drug', 'jaccard_index', 'n_intersection', 'n_union']
     )
+    jaccard_df_per_pair = DataFrame(
+        data=jr,
+        columns=['drugA', 'drugB', 'corr', 'jaccard_index',
+                 'n_intersection', 'n_union']
+    ).sort_values(by=['jaccard_index', 'corr'], ascending=[False, True])
+    logger.info('Done with script, results are in variables '
+                '`overall_ranking`, `jaccard_df_per_drug` and '
+                '`jaccard_df_per_pair`')

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -1,8 +1,12 @@
 import sys
 import numpy as np
+import logging
 from collections import Counter
 from depmap_analysis.util.io_functions import file_opener
 from depmap_analysis.util.statistics import DepMapExplainer
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_rankings(expl_df, sampl_size=None):
@@ -27,6 +31,7 @@ def get_rankings(expl_df, sampl_size=None):
     )
     if sampl_size and sampl_size < len(all_agents_sampled):
         # Sample rows
+        logger.info(f'Downsizing to {sampl_size}')
         all_agents_sampled = np.random.choice(list(all_agents_sampled),
                                               sampl_size, replace=False)
 

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -109,13 +109,13 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
                                          {'tas', 'drugbank'})
                 l1_int = set(l1_a_succ) & set(l1_b_succ)
                 l1_uni = set(l1_a_succ) | set(l1_b_succ)
-                l1_ji = len(l1_int)/len(l1_uni)
+                l1_ji = len(l1_int)/len(l1_uni) if len(l1_uni) else 0
                 # L2
                 l2_a_succ = _get_sources(graph, agA, l0_a_succ, {'drugbank'})
                 l2_b_succ = _get_sources(graph, agB, l0_b_succ, {'drugbank'})
                 l2_int = set() & set()
                 l2_uni = set() | set()
-                l2_ji = len(l2_int)/len(l2_uni)
+                l2_ji = len(l2_int)/len(l2_uni) if len(l2_uni) else 0
             # If no graph, just set None
             else:
                 l1_a_succ, l1_b_succ, l1_int, l1_uni, l1_ji = (None,) * 5

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -129,7 +129,7 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
                  l3_a_succ, l3_b_succ, l3_int, l3_uni, l3_ji)
             )
     output_cols = (
-        'drugA', 'drugB', 'corr',
+        'drugA', 'drugB', 'correlation',
 
         'l0_succ_a', 'l0_succ_b', 'l0_intersection',
         'l0_union', 'l0_jaccard_index',

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -90,11 +90,13 @@ def get_rankings(expl_df: DataFrame, stats_df: DataFrame,
 
     nnn_counters = {}  # Counters of the intersection of downstream targets
     jaccard_index = defaultdict(list)
-    expl_df = expl_df[expl_df['expl type'] == 'shared downstream']
     for ag_name in all_agents_sampled:
         ll = []
-        for ins, uni in expl_df['expl data'][(expl_df.agA == ag_name) |
-                                             (expl_df.agB == ag_name)].values:
+        for sd_a_succ, sd_b_succ, ins, uni in \
+                expl_df['expl data'][
+                    ((expl_df.agA == ag_name) | (expl_df.agB == ag_name)) &
+                    (expl_df['expl type'] == 'shared downstream')
+                ].values:
             ll += ins
             jaccard_index[ag_name].append((len(ins), len(uni),
                                            len(ins)/len(uni)))
@@ -140,7 +142,7 @@ if __name__ == '__main__':
             'succ_a_st', 'succ_b_st', 'n_st_intersection', 'n_st_union',
             'succ_a_sd', 'succ_b_sd', 'n_sd_intersection', 'n_sd_union'
         ]
-    ).sort_values(by=['jaccard_index', 'corr'], ascending=[False, True])
+    )
     logger.info('Done with script, results are in variables '
                 '`overall_ranking`, `jaccard_df_per_drug` and '
                 '`jaccard_df_per_pair`')

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -55,3 +55,8 @@ if __name__ == '__main__':
     drug_expl = file_opener(drug_file)
     assert isinstance(drug_expl, DepMapExplainer)
     rankings = get_rankings(drug_expl.expl_df)
+
+    # Sum up the counters to get a full counter
+    overall_ranking = Counter()
+    for c in rankings.values():
+        overall_ranking += c

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -2,6 +2,7 @@ import sys
 import numpy as np
 from collections import Counter
 from depmap_analysis.util.io_functions import file_opener
+from depmap_analysis.util.statistics import DepMapExplainer
 
 
 def get_rankings(expl_df, sampl_size=None):
@@ -47,4 +48,5 @@ if __name__ == '__main__':
     except IndexError:
         sample_size = None
     drug_expl = file_opener(drug_file)
-    rankings = get_rankings(drug_expl)
+    assert isinstance(drug_expl, DepMapExplainer)
+    rankings = get_rankings(drug_expl.expl_df)

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -65,7 +65,7 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
     for (agA, agB, corr, _, _, _, _, _, _, _, _) in \
             stats_df[stats_df.explained == True].itertuples(index=False):
         if agA != agB:
-            l0_a_succ, l0_b_succ, l0_int, l0_uni = ([],) * 4
+            l2_a_succ, l2_b_succ, l2_int, l2_uni = ([],) * 4
             l3_a_succ, l3_b_succ, l3_int, l3_uni = ([],) * 4
 
             for n, (expl_type, expl_data) in enumerate(
@@ -87,39 +87,39 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
 
                 if expl_data is not None:
                     if expl_type == 'shared target':
-                        l0_a_succ, l0_b_succ, l0_int, l0_uni = expl_data
+                        l2_a_succ, l2_b_succ, l2_int, l2_uni = expl_data
                     elif expl_type == 'shared downstream':
                         l3_a_succ, l3_b_succ, l3_int, l3_uni = expl_data
                     else:
                         continue
             # Save:
             # A, B, corr, st JI, sd JI,
-            # l0_a, l0_b, l0_int, l0_uni,
+            # l2_a, l2_b, l2_int, l2_uni,
             # l3_a, l3_b, l3_int, l3_uni
-            l0_ji = len(l0_int) / len(l0_uni) if len(l0_uni) else 0
+            l2_ji = len(l2_int) / len(l2_uni) if len(l2_uni) else 0
             l3_ji = len(l3_int) / len(l3_uni) if len(l3_uni) else 0
 
             # Get the l1 and l2 columns
             if graph:
                 # Get filtered successors
+                # L0
+                l0_a_succ = _get_sources(graph, agA, l2_a_succ, {'drugbank'})
+                l0_b_succ = _get_sources(graph, agB, l2_b_succ, {'drugbank'})
+                l0_int = set() & set()
+                l0_uni = set() | set()
+                l0_ji = len(l0_int)/len(l0_uni) if len(l0_uni) else 0
                 # L1
-                l1_a_succ = _get_sources(graph, agA, l0_a_succ,
-                                         {'tas', 'drugbank'})
-                l1_b_succ = _get_sources(graph, agB, l0_b_succ,
-                                         {'tas', 'drugbank'})
+                l1_a_succ = _get_sources(
+                    graph, agA, l2_a_succ, {'tas', 'drugbank'})
+                l1_b_succ = _get_sources(
+                    graph, agB, l2_b_succ, {'tas', 'drugbank'})
                 l1_int = set(l1_a_succ) & set(l1_b_succ)
                 l1_uni = set(l1_a_succ) | set(l1_b_succ)
                 l1_ji = len(l1_int)/len(l1_uni) if len(l1_uni) else 0
-                # L2
-                l2_a_succ = _get_sources(graph, agA, l0_a_succ, {'drugbank'})
-                l2_b_succ = _get_sources(graph, agB, l0_b_succ, {'drugbank'})
-                l2_int = set() & set()
-                l2_uni = set() | set()
-                l2_ji = len(l2_int)/len(l2_uni) if len(l2_uni) else 0
             # If no graph, just set None
             else:
+                l0_a_succ, l0_b_succ, l0_int, l0_uni, l0_ji = (None,) * 5
                 l1_a_succ, l1_b_succ, l1_int, l1_uni, l1_ji = (None,) * 5
-                l2_a_succ, l2_b_succ, l2_int, l2_uni, l2_ji = (None,) * 5
 
             jaccard_ranks.append(
                 (agA, agB, corr,
@@ -131,17 +131,17 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
     output_cols = (
         'drugA', 'drugB', 'correlation',
 
-        'l0_succ_a', 'l0_succ_b', 'l0_intersection',
-        'l0_union', 'l0_jaccard_index',
+        'L0_succ_a', 'L0_succ_b', 'L0_intersection',
+        'L0_union', 'L0_jaccard_index',
 
-        'l1_succ_a', 'l1_succ_b', 'l1_intersection',
-        'l1_union', 'l1_jaccard_index',
+        'L1_succ_a', 'L1_succ_b', 'L1_intersection',
+        'L1_union', 'L1_jaccard_index',
 
-        'l2_succ_a', 'l2_succ_b', 'l2_intersection',
-        'l2_union', 'l2_jaccard_index',
+        'L2_succ_a', 'L2_succ_b', 'L2_intersection',
+        'L2_union', 'L2_jaccard_index',
 
-        'l3_succ_a', 'l3_succ_b', 'l3_intersection',
-        'l3_union', 'l3_jaccard_index'
+        'L3_succ_a', 'L3_succ_b', 'L3_intersection',
+        'L3_union', 'L3_jaccard_index'
     )
     return pd.DataFrame(data=jaccard_ranks, columns=output_cols)
 

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -73,15 +73,16 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
                         ((expl_df.agA == agA) & (expl_df.agB == agB) |
                          (expl_df.agA == agB) & (expl_df.agB == agA))
                     ].itertuples(index=False)):
-                if n > 1:
+                if n >= 2:
                     # raise IndexError('Should not have more than one '
                     #                  'explanation per (A,B) pair per '
                     #                  'category ("shared downstream" and '
                     #                  '"shared target" should be only '
                     #                  'explanations)')
                     # Todo: handle misnamed entities
-                    logger.warning(f'Skipping unexpected data from {agA}, '
-                                   f'{agB}')
+                    if n == 2:
+                        logger.warning(f'Unexpected data from {agA}, {agB}, '
+                                       f'skipping further data')
                     continue
 
                 if expl_data is not None:

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -35,15 +35,15 @@ def get_rankings(expl_df, sampl_size=None):
         all_agents_sampled = np.random.choice(list(all_agents_sampled),
                                               sampl_size, replace=False)
 
-    nnn_expl = {}
+    nnn_counters = {}
     expl_df = expl_df[expl_df['expl type'] == 'shared downstream']
     for ag_name in all_agents_sampled:
         ll = []
         for lk in expl_df['expl data'][(expl_df.agA == ag_name) |
                                        (expl_df.agB == ag_name)].values:
             ll += lk
-        nnn_expl[ag_name] = Counter(ll)
-    return nnn_expl
+        nnn_counters[ag_name] = Counter(ll)
+    return nnn_counters
 
 
 if __name__ == '__main__':

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -81,13 +81,6 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
                         ((expl_df.agA == agA) & (expl_df.agB == agB) |
                          (expl_df.agA == agB) & (expl_df.agB == agA))
                     ].itertuples(index=False)):
-                if expl_data is not None:
-                    if expl_type == 'shared target':
-                        st_a_succ, st_b_succ, st_int, st_uni = expl_data
-                    elif expl_type == 'shared downstream':
-                        sd_a_succ, sd_b_succ, sd_int, sd_uni = expl_data
-                    else:
-                        continue
                 if n > 1:
                     # raise IndexError('Should not have more than one '
                     #                  'explanation per (A,B) pair per '
@@ -98,6 +91,14 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
                     logger.warning(f'Skipping unexpected data from {agA}, '
                                    f'{agB}')
                     continue
+
+                if expl_data is not None:
+                    if expl_type == 'shared target':
+                        st_a_succ, st_b_succ, st_int, st_uni = expl_data
+                    elif expl_type == 'shared downstream':
+                        sd_a_succ, sd_b_succ, sd_int, sd_uni = expl_data
+                    else:
+                        continue
             # Save:
             # A, B, corr, st JI, sd JI,
             # a_st, b_st, st_int, st_uni,

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -1,7 +1,9 @@
 import sys
 import numpy as np
 import logging
+from typing import Dict
 from collections import Counter
+from pandas import DataFrame
 from depmap_analysis.util.io_functions import file_opener
 from depmap_analysis.util.statistics import DepMapExplainer
 
@@ -9,12 +11,13 @@ from depmap_analysis.util.statistics import DepMapExplainer
 logger = logging.getLogger(__name__)
 
 
-def get_rankings(expl_df, sampl_size=None):
+def get_rankings(expl_df: DataFrame, sampl_size: int = None)\
+        -> Dict[str, Counter]:
     """Get the count of next nearest neighborhood
 
     Parameters
     ----------
-    expl_df : pd.DataFrame
+    expl_df : DataFrame
         Explanation dataframe
     sampl_size : int
         Sampling size.

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -99,8 +99,8 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
     # n_a_sd, n_b_sd, sd_int, sd_uni
     output_cols = (
         'drugA', 'drugB', 'corr', 'st_jaccard_index', 'sd_jaccard_index',
-        'succ_a_st', 'succ_b_st', 'n_st_intersection', 'n_st_union',
-        'succ_a_sd', 'succ_b_sd', 'n_sd_intersection', 'n_sd_union'
+        'succ_a_st', 'succ_b_st', 'st_intersection', 'st_union',
+        'succ_a_sd', 'succ_b_sd', 'sd_intersection', 'sd_union'
     )
     return pd.DataFrame(data=jaccard_ranks, columns=output_cols)
 

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -1,0 +1,50 @@
+import sys
+import numpy as np
+from collections import Counter
+from depmap_analysis.util.io_functions import file_opener
+
+
+def get_rankings(expl_df, sampl_size=None):
+    """Get the count of next nearest neighborhood
+
+    Parameters
+    ----------
+    expl_df : pd.DataFrame
+        Explanation dataframe
+    sampl_size : int
+        Sampling size.
+
+    Returns
+    -------
+    dict
+        A dict of Counters for each examined agent
+    """
+    # Get the agents that have any shared downstream explanations
+    all_agents_sampled = set(
+        set(expl_df[expl_df['expl type'] == 'shared downstream'].agA.values) &
+        set(expl_df[expl_df['expl type'] == 'shared downstream'].agB.values)
+    )
+    if sampl_size and sampl_size < len(all_agents_sampled):
+        # Sample rows
+        all_agents_sampled = np.random.choice(list(all_agents_sampled),
+                                              sampl_size, replace=False)
+
+    nnn_expl = {}
+    expl_df = expl_df[expl_df['expl type'] == 'shared downstream']
+    for ag_name in all_agents_sampled:
+        ll = []
+        for lk in expl_df['expl data'][(expl_df.agA == ag_name) |
+                                       (expl_df.agB == ag_name)].values:
+            ll += lk
+        nnn_expl[ag_name] = Counter(ll)
+    return nnn_expl
+
+
+if __name__ == '__main__':
+    drug_file = sys.argv[1]
+    try:
+        sample_size = sys.argv[2]
+    except IndexError:
+        sample_size = None
+    drug_expl = file_opener(drug_file)
+    rankings = get_rankings(drug_expl)

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -125,10 +125,11 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
     df = pd.DataFrame(data=jaccard_ranks, columns=output_cols)
 
     # Add some columns
-    df['agA_percent_in_tas_db'] = df.apply(_percent_in_tas_or_db_A, axis=1)
-    df['agB_percent_in_tas_db'] = df.apply(_percent_in_tas_or_db_B, axis=1)
-    df['percent_in_tas_db'] = 0.5*(df.agB_percent_in_tas_db +
-                                   df.agA_percent_in_tas_db)
+    if graph:
+        df['agA_percent_in_tas_db'] = df.apply(_percent_in_tas_or_db_A, axis=1)
+        df['agB_percent_in_tas_db'] = df.apply(_percent_in_tas_or_db_B, axis=1)
+        df['percent_in_tas_db'] = 0.5*(df.agB_percent_in_tas_db +
+                                       df.agA_percent_in_tas_db)
     return df
 
 

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -57,11 +57,15 @@ def get_rankings(expl_df: DataFrame, stats_df: DataFrame,
                     else:
                         continue
                 if n > 1:
-                    raise IndexError('Should not have more than one '
-                                     'explanation per (A,B) pair per '
-                                     'category ("shared downstream" and '
-                                     '"shared target" should be only '
-                                     'explanations)')
+                    # raise IndexError('Should not have more than one '
+                    #                  'explanation per (A,B) pair per '
+                    #                  'category ("shared downstream" and '
+                    #                  '"shared target" should be only '
+                    #                  'explanations)')
+                    # Todo: handle misnamed entities
+                    logger.warning(f'Skipping unexpected data from {agA}, '
+                                   f'{agB}')
+                    continue
             # Save:
             # A, B, corr, st JI, sd JI,
             # n_a_st, n_b_st, st_int, st_uni,

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_rankings(expl_df: DataFrame, sampl_size: int = None)\
-        -> Tuple[Dict[str, Counter], Dict[str, List[float]]]:
+        -> Tuple[Dict[str, Counter], Dict[str, List[Tuple[int, int, float]]]]:
     """Get the count of next nearest neighborhood
 
     Parameters
@@ -45,7 +45,8 @@ def get_rankings(expl_df: DataFrame, sampl_size: int = None)\
         for ins, uni in expl_df['expl data'][(expl_df.agA == ag_name) |
                                              (expl_df.agB == ag_name)].values:
             ll += ins
-            jaccard_index[ag_name].append((len(ins)/len(uni)))
+            jaccard_index[ag_name].append((len(ins), len(uni),
+                                           len(ins)/len(uni)))
         nnn_counters[ag_name] = Counter(ll)
     return nnn_counters, jaccard_index
 
@@ -66,5 +67,15 @@ if __name__ == '__main__':
         overall_ranking += c
 
     # Get average Jaccard index per drug
-    jaccard_ranking = [(name, sum(jvs)/len(jvs)) for name, jvs in ji.items()]
+    jaccard_ranking = []
+    for name, jvs in ji.items():
+        li, lu, ljr = list(zip(*jvs))
+        jaccard_ranking.append((name,
+                                sum(ljr)/len(ljr),
+                                sum(li)/len(li),
+                                sum(lu)/len(lu)))
     jaccard_ranking.sort(key=lambda t: t[1], reverse=True)
+    jaccard_df = DataFrame(
+        data=jaccard_ranking,
+        columns=['drug', 'jaccard_index', 'n_intersection', 'n_union']
+    )

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -28,10 +28,9 @@ def get_rankings(expl_df: DataFrame, sampl_size: int = None)\
         A dict of Counters for each examined agent
     """
     # Get the agents that have any shared downstream explanations
-    all_agents_sampled = set(
-        set(expl_df[expl_df['expl type'] == 'shared downstream'].agA.values) &
+    all_agents_sampled = \
+        set(expl_df[expl_df['expl type'] == 'shared downstream'].agA.values) |\
         set(expl_df[expl_df['expl type'] == 'shared downstream'].agB.values)
-    )
     if sampl_size and sampl_size < len(all_agents_sampled):
         # Sample rows
         logger.info(f'Downsizing to {sampl_size}')

--- a/depmap_analysis/scripts/drug_script.py
+++ b/depmap_analysis/scripts/drug_script.py
@@ -44,7 +44,7 @@ def get_jaccard_rankings_per_pair(expl_df: pd.DataFrame,
             w_srcs.append((x, list(x_srcs)))
         return w_srcs
 
-    if graph is not None:
+    if graph is None:
         logger.info('No graph provided, will skip getting sources of targets')
     jaccard_ranks = []
 


### PR DESCRIPTION
This PR adds a new post analysis script in `depmap_analysis/scripts/drug_script.py`. The script is intended to be run after the depmap script (`depmap_analysis/script/depmap_script2.py`) has been run.

This PR should be merged after #48 is merged and rebased in master after the merge.

The script runs an analysis that calculates the Jaccard index based on a couple of criteria for different explanations. For each pair of drugs, the following is surfaced and calculated:

The following columns are provided to identify the drug pair
- The name of drug A
- The name of drug B
- The correlation between drug A and B of the drug effect across multiple cell lines

The following columns are calculated in four different categories:
- The downstream nodes of drug A
- The downstream nodes of drug B
- The union of nodes downstream of drug A and B
- The intersection of nodes downstream of drug A and B
- The Jaccard index

The four different categories for which this is done is:
- L0: Downstream nodes one edge away supported by any source
- L1: Downstream nodes one edge away supported by at least `drugbank` or `TAS` as sources
- L2:  Downstream nodes one edge away supported by at least `drugbank` as source
- L3:  Downstream nodes two edges away supported by any source