### PR TITLE
Update graph dumping

### DIFF
--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -149,14 +149,6 @@ def sif_dump_df_merger(df, mesh_id_dict=None, set_weights=True, verbosity=0):
     df : str|pd.DataFrame
         A dataframe, either as a file path to a pickle or csv, or a pandas
         DataFrame object.
-    belief_dict : str|dict
-        The file path to a pickled dict or a dict object keyed by statement
-        hash containing the belief score for the corresponding statements.
-        The hashes should correspond to the hashes in the loaded dataframe.
-    strat_ev_dict : str|dict
-        The file path to a pickled dict or a dict object keyed by statement
-        hash containing the stratified evidence count per statement. The
-        hashes should correspond to the hashes in the loaded dataframe.
     mesh_id_dict : dict
         A dict object mapping statement hashes to all mesh ids sharing a 
         common PMID
@@ -249,14 +241,6 @@ def sif_dump_df_to_digraph(df, mesh_id_dict=None,
     df : str|pd.DataFrame
         A dataframe, either as a file path to a file (.pkl or .csv) or a
         pandas DataFrame object.
-    belief_dict : str|dict
-        The file path to a pickled dict or a dict object keyed by statement
-        hash containing the belief score for the corresponding statements.
-        The hashes should correspond to the hashes in the loaded dataframe.
-    strat_ev_dict : str|dict
-        The file path to a pickled dict or a dict object keyed by statement
-        hash containing the stratified evidence count per statement. The
-        hashes should correspond to the hashes in the loaded dataframe.
     mesh_id_dict : dict
         A dict object mapping statement hashes to all mesh ids sharing a 
         common PMID

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -450,6 +450,8 @@ def sif_dump_df_to_digraph(df: Union[pd.DataFrame, str],
         signed_node_graph: DiGraph = signed_edges_to_signed_nodes(
             graph=signed_edge_graph, copy_edge_data=True
         )
+        signed_edge_graph.graph['date'] = date
+        signed_node_graph.graph['date'] = date
         signed_edge_graph.graph['node_by_ns_id'] = ns_id_to_nodename
         signed_node_graph.graph['node_by_ns_id'] = ns_id_to_nodename
 

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -1,5 +1,6 @@
 import logging
 from decimal import Decimal
+from datetime import datetime
 from itertools import cycle
 from collections import defaultdict
 import subprocess
@@ -230,7 +231,7 @@ def sif_dump_df_merger(df, mesh_id_dict=None, set_weights=True, verbosity=0):
     return merged_df
 
 
-def sif_dump_df_to_digraph(df, mesh_id_dict=None,
+def sif_dump_df_to_digraph(df, date=None, mesh_id_dict=None,
                            graph_type='digraph',
                            include_entity_hierarchies=True,
                            verbosity=0):
@@ -241,6 +242,8 @@ def sif_dump_df_to_digraph(df, mesh_id_dict=None,
     df : str|pd.DataFrame
         A dataframe, either as a file path to a file (.pkl or .csv) or a
         pandas DataFrame object.
+    date : str
+        A date string specifying when the data was dumped from the database.
     mesh_id_dict : dict
         A dict object mapping statement hashes to all mesh ids sharing a 
         common PMID
@@ -263,6 +266,7 @@ def sif_dump_df_to_digraph(df, mesh_id_dict=None,
         raise ValueError('Graph type %s not supported. Can only chose between'
                          ' %s' % (graph_type, graph_options))
     graph_type = graph_type.lower()
+    date = date if date else datetime.now().strftime('%Y-%m-%d')
 
     sif_df = sif_dump_df_merger(df, mesh_id_dict, verbosity=verbosity)
 
@@ -396,6 +400,7 @@ def sif_dump_df_to_digraph(df, mesh_id_dict=None,
         indranet_graph.graph['node_by_uri'] = node_by_uri
     indranet_graph.graph['node_by_ns_id'] = ns_id_to_nodename
     indranet_graph.graph['edge_by_hash'] = hash_edge_dict
+    indranet_graph.graph['date'] = date
     return indranet_graph
 
 

--- a/depmap_analysis/network_functions/net_functions.py
+++ b/depmap_analysis/network_functions/net_functions.py
@@ -458,16 +458,22 @@ def sif_dump_df_to_digraph(df: Union[pd.DataFrame, str],
         # Get hash to signed edge mapping
         logger.info('Creating dictionary mapping hashes to edges for '
                     'unsigned graph')
-        seg_hash_edge_dict = {}
+        seg_hash_edge_dict = {} if graph_type == 'signed' else defaultdict(set)
         for edge in signed_edge_graph.edges:
             for es in signed_edge_graph.edges[edge]['statements']:
-                seg_hash_edge_dict[es['stmt_hash']] = edge
+                if graph_type == 'signed':
+                    seg_hash_edge_dict[es['stmt_hash']] = edge
+                else:
+                    seg_hash_edge_dict[es['stmt_hash']].add(edge)
         signed_edge_graph.graph['edge_by_hash'] = seg_hash_edge_dict
 
-        sng_hash_edge_dict = {}
+        sng_hash_edge_dict = {} if graph_type == 'signed' else defaultdict(set)
         for edge in signed_node_graph.edges:
             for es in signed_node_graph.edges[edge]['statements']:
-                sng_hash_edge_dict[es['stmt_hash']] = edge
+                if graph_type == 'signed':
+                    sng_hash_edge_dict[es['stmt_hash']] = edge
+                else:
+                    sng_hash_edge_dict[es['stmt_hash']].add(edge)
         signed_node_graph.graph['edge_by_hash'] = sng_hash_edge_dict
 
         return signed_edge_graph, signed_node_graph

--- a/depmap_analysis/scripts/dump_new_graphs.py
+++ b/depmap_analysis/scripts/dump_new_graphs.py
@@ -36,7 +36,7 @@ def dump_new_nets(mdg: bool = False, dg: bool = False, sg: bool = False,
         df, sif_date = get_latest_sif_s3()
 
     options.update({'df': df, 'include_entity_hierarchies': True,
-                    'verbosity': verbosity})
+                    'verbosity': verbosity, 'date': sif_date})
     prefix = f'{NETS_PREFIX}/{sif_date}'
     if mdg:
         network = nf.sif_dump_df_to_digraph(graph_type='multi', **options)

--- a/depmap_analysis/scripts/dump_new_graphs.py
+++ b/depmap_analysis/scripts/dump_new_graphs.py
@@ -66,9 +66,5 @@ if __name__ == '__main__':
     parser.add_argument('--pb', help='Dump new PyBel signed edge and node '
                                      'graphs',
                         action='store_true', default=False)
-    parser.add_argument('--s3', help='Also upload the new graphs to s3',
-                        action='store_true', default=False)
-    parser.add_argument('--overwrite', help='Overwrite local files',
-                        action='store_true', default=False)
     args = parser.parse_args()
     dump_new_nets(mdg=args.mdg, dg=args.dg, sg=args.sg, spbg=args.pb)

--- a/depmap_analysis/scripts/dump_new_graphs.py
+++ b/depmap_analysis/scripts/dump_new_graphs.py
@@ -22,16 +22,15 @@ def dump_new_nets(mdg: bool = False, dg: bool = False, sg: bool = False,
     options = dict()
 
     if add_mesh_ids:
-        df, sev, bd, mid = get_latest_sif_s3(get_mesh_ids=True)
+        df, mid = get_latest_sif_s3(get_mesh_ids=True)
         mid_dict = dict()
         for pair in mid:
             mid_dict.setdefault(pair[0], []).append(pair[1])
         options['mesh_id_dict'] = mid_dict
     else:
-        df, sev, bd = get_latest_sif_s3()
+        df = get_latest_sif_s3()
 
-    options.update({'df': df, 'belief_dict': bd, 'strat_ev_dict': sev,
-                    'include_entity_hierarchies': True,
+    options.update({'df': df, 'include_entity_hierarchies': True,
                     'verbosity': verbosity})
 
     if mdg:

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -4,19 +4,28 @@ from depmap_analysis.network_functions.net_functions import \
     sif_dump_df_to_digraph
 
 # Add input
+agA_names = ['nameX1', 'nameX2']
+agA_ns_list = ['nsX1', 'nsX2']
+agA_ids = ['idX1', 'idX2']
+agB_names = ['nameY1', 'nameY2']
+agB_ns_list = ['nsY1', 'nsY2']
+agB_ids = ['idY1', 'idY2']
 h1, h2 = 1234657890, 9876543210
 hashes = [h1, h2]
 bd = [0.685, 0.95]
+stmt_types = ['Activation', 'Complex']
+ev_counts = [7, 13]
 src = [{'srcA': 2, 'srcB': 5}, {'srcA': 5, 'srcB': 8}]
-sif = {'agA_name': ['nameX1', 'nameX2'], 'agA_ns': ['nsX1', 'nsX2'],
-       'agA_id': ['idX1', 'idX2'], 'agB_name': ['nameY1', 'nameY2'],
-       'agB_ns': ['nsY1', 'nsY2'], 'agB_id': ['idY1', 'idY2'],
-       'stmt_type': ['Activation', 'Complex'], 'evidence_count': [7, 13],
-       'stmt_hash': hashes, 'source_counts': src, 'belief': bd}
+
+sif_dict = {'agA_name': agA_names, 'agA_ns': agA_ns_list,
+            'agA_id': agA_ids, 'agB_name': agB_names, 'agB_ns': agB_ns_list,
+            'agB_id': agB_ids, 'stmt_type': stmt_types,
+            'evidence_count': ev_counts, 'stmt_hash': hashes,
+            'source_counts': src, 'belief': bd}
 
 
 def test_digraph_dump():
-    sif_df = pd.DataFrame(sif)
+    sif_df = pd.DataFrame(sif_dict)
     idg = sif_dump_df_to_digraph(df=sif_df,
                                  date=datetime.utcnow().strftime('%Y-%m-%d'),
                                  graph_type='digraph',

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -1,3 +1,6 @@
+# todo:
+#  -Test famplex edges
+#  -How to map hashes to expanded sign edges
 from networkx import DiGraph, MultiDiGraph
 from datetime import datetime
 from typing import Tuple
@@ -39,10 +42,10 @@ def test_df_from_dict():
 
 def test_digraph_dump():
     sif_df = _get_df()
-    idg = sif_dump_df_to_digraph(df=sif_df,
-                                 date=datetime.utcnow().strftime('%Y-%m-%d'),
-                                 graph_type='digraph',
-                                 include_entity_hierarchies=False)
+    date = datetime.utcnow().strftime('%Y-%m-%d')
+    idg: DiGraph = sif_dump_df_to_digraph(df=sif_df, date=date,
+                                          graph_type='digraph',
+                                          include_entity_hierarchies=False)
     assert idg.graph.get('edge_by_hash')
     assert idg.graph.get('date')
     assert idg.graph.get('node_by_ns_id')

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -1,4 +1,6 @@
+from networkx import DiGraph, MultiDiGraph
 from datetime import datetime
+from typing import Tuple
 import pandas as pd
 from depmap_analysis.network_functions.net_functions import \
     sif_dump_df_to_digraph
@@ -51,11 +53,61 @@ def test_digraph_dump():
            h1
 
 
-def test_digraph_signed_types_dump():
-    pass
-
-
 def test_signed_graph_dump():
+    sif_df = _get_df()
+    signed_edge1 = (agA_names[0], agB_names[0], 0)
+    sign_node_edge1 = ((agA_names[0], 0), (agB_names[0], 0))
+    date = datetime.utcnow().strftime('%Y-%m-%d')
+    seg, sng = \
+        sif_dump_df_to_digraph(df=sif_df, date=date, graph_type='signed',
+                               include_entity_hierarchies=False)
+    assert isinstance(seg, MultiDiGraph), str(seg.__class__)
+    assert isinstance(sng, DiGraph), str(sng.__class__)
+
+    # Check signed edge graph
+    assert seg.graph.get('edge_by_hash')
+    assert seg.graph['edge_by_hash'][h1] == signed_edge1
+    assert seg.graph.get('node_by_ns_id')
+    assert seg.graph.get('date') == date
+    assert len(seg.edges) == 1, len(seg.edges)
+    # All nodes added, skip doesn't happen until nodes added
+    assert len(seg.nodes) == 4, len(seg.nodes)
+    assert seg.nodes[signed_edge1[0]] == {'ns': agA_ns_list[0],
+                                          'id': agA_ids[0]}
+    assert seg.edges.get(signed_edge1)
+    assert 'weight' in seg.edges[signed_edge1]
+    assert isinstance(seg.edges[signed_edge1]['statements'], list)
+    sd = seg.edges[signed_edge1]['statements'][0]
+    assert sd['stmt_hash'] == h1
+    assert sd['stmt_type'] == stmt_types[0]
+    assert sd['belief'] == bd[0]
+    assert sd['evidence_count'] == ev_counts[0]
+    assert sd['source_counts'] == src[0]
+    assert 'curated' in sd
+
+    # Check signed node graph
+    assert sng.graph.get('edge_by_hash')
+    assert sng.graph['edge_by_hash'][h1] == sign_node_edge1
+    assert sng.graph.get('node_by_ns_id')
+    assert sng.graph.get('date') == date
+    assert len(sng.edges) == 1
+    # All nodes added, skip doesn't happen until nodes added
+    assert len(sng.nodes) == 4
+    assert sng.nodes[sign_node_edge1[0]] == {'ns': agA_ns_list[0],
+                                             'id': agA_ids[0]}
+    assert sng.edges.get(sign_node_edge1)
+    assert 'weight' in sng.edges[sign_node_edge1]
+    assert isinstance(sng.edges[sign_node_edge1]['statements'], list)
+    sd = sng.edges[sign_node_edge1]['statements'][0]
+    assert sd['stmt_hash'] == h1
+    assert sd['stmt_type'] == stmt_types[0]
+    assert sd['belief'] == bd[0]
+    assert sd['evidence_count'] == ev_counts[0]
+    assert sd['source_counts'] == src[0]
+    assert 'curated' in sd
+
+
+def test_digraph_signed_types_dump():
     pass
 
 

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -2,6 +2,7 @@ from networkx import DiGraph, MultiDiGraph
 from datetime import datetime
 from typing import Tuple
 import pandas as pd
+from indra.assemblers.indranet.net import default_sign_dict
 from depmap_analysis.network_functions.net_functions import \
     sif_dump_df_to_digraph
 
@@ -108,7 +109,21 @@ def test_signed_graph_dump():
 
 
 def test_digraph_signed_types_dump():
-    pass
+    sif_df = _get_df()
+    date = datetime.utcnow().strftime('%Y-%m-%d')
+    edge = (agA_names[0], agB_names[0])
+    dg_st = sif_dump_df_to_digraph(df=sif_df, date=date,
+                                   graph_type='digraph-signed-types',
+                                   include_entity_hierarchies=False)
+    assert dg_st.graph.get('edge_by_hash')
+    assert dg_st.graph['edge_by_hash'][h1] == edge
+    assert dg_st.graph.get('node_by_ns_id')
+    assert dg_st.graph.get('date') == date
+    assert len(dg_st.edges) == 1, len(dg_st.edges)
+    assert len(dg_st.nodes) == 2, len(dg_st.nodes)
+    assert all(all([sd['stmt_type'] in default_sign_dict
+                    for sd in data['statements']])
+               for _, _, data in dg_st.edges(data=True))
 
 
 def test_expanded_signed_graph_dump():

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -127,4 +127,70 @@ def test_digraph_signed_types_dump():
 
 
 def test_expanded_signed_graph_dump():
-    pass
+    sif_df = _get_df()
+    signed_edge1 = (agA_names[0], agB_names[0], 0)
+    signed_edge2 = (agA_names[1], agB_names[1], 0)
+    signed_edge3 = (agA_names[1], agB_names[1], 1)
+    sign_node_edge1 = ((agA_names[0], 0), (agB_names[0], 0))
+    sign_node_edge2 = ((agA_names[1], 0), (agB_names[1], 0))
+    sign_node_edge3 = ((agA_names[1], 0), (agB_names[1], 1))
+    date = datetime.utcnow().strftime('%Y-%m-%d')
+    seg, sng = \
+        sif_dump_df_to_digraph(df=sif_df, date=date,
+                               graph_type='signed-expanded',
+                               stmt_types=['Complex'],
+                               include_entity_hierarchies=False)
+    assert isinstance(seg, MultiDiGraph), str(seg.__class__)
+    assert isinstance(sng, DiGraph), str(sng.__class__)
+
+    # Check signed edge graph
+    assert seg.graph.get('edge_by_hash')
+    assert seg.graph['edge_by_hash'][h1] == signed_edge1
+    # Todo: fix the hash to node mapping for expanded graphs: h2 maps to two
+    #  edges
+    assert seg.graph['edge_by_hash'][h2] == signed_edge3
+    assert seg.graph.get('node_by_ns_id')
+    assert seg.graph.get('date') == date
+    assert len(seg.edges) == 3, len(seg.edges)
+    assert len(seg.nodes) == 4, len(seg.nodes)
+    assert seg.nodes[signed_edge1[0]] == {'ns': agA_ns_list[0],
+                                          'id': agA_ids[0]}
+    assert seg.nodes[signed_edge2[0]] == {'ns': agA_ns_list[1],
+                                          'id': agA_ids[1]}
+    assert seg.edges.get(signed_edge1)
+    assert seg.edges.get(signed_edge2)
+    assert seg.edges.get(signed_edge3)
+    assert 'weight' in seg.edges[signed_edge2]
+    assert isinstance(seg.edges[signed_edge2]['statements'], list)
+    assert isinstance(seg.edges[signed_edge3]['statements'], list)
+    sd = seg.edges[signed_edge3]['statements'][0]
+    assert sd['stmt_hash'] == h2
+    assert sd['stmt_type'] == stmt_types[1]
+    assert sd['belief'] == bd[1]
+    assert sd['evidence_count'] == ev_counts[1]
+    assert sd['source_counts'] == src[1]
+    assert 'curated' in sd
+
+    # Check signed node graph
+    assert sng.graph.get('edge_by_hash')
+    assert sng.graph['edge_by_hash'][h1] == sign_node_edge1
+    # Todo: fix the hash to node mapping for expanded graphs: h2 maps to two
+    #  edges
+    assert sng.graph['edge_by_hash'][h2] == sign_node_edge3
+    assert sng.graph.get('node_by_ns_id')
+    assert sng.graph.get('date') == date
+    assert len(sng.edges) == 3
+    assert len(sng.nodes) == 5
+    assert sng.nodes[sign_node_edge2[0]] == {'ns': agA_ns_list[1],
+                                             'id': agA_ids[1]}
+    assert sng.edges.get(sign_node_edge2)
+    assert sng.edges.get(sign_node_edge3)
+    assert 'weight' in sng.edges[sign_node_edge3]
+    assert isinstance(sng.edges[sign_node_edge3]['statements'], list)
+    sd = sng.edges[sign_node_edge3]['statements'][0]
+    assert sd['stmt_hash'] == h2
+    assert sd['stmt_type'] == stmt_types[1]
+    assert sd['belief'] == bd[1]
+    assert sd['evidence_count'] == ev_counts[1]
+    assert sd['source_counts'] == src[1]
+    assert 'curated' in sd

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -148,10 +148,9 @@ def test_expanded_signed_graph_dump():
 
     # Check signed edge graph
     assert seg.graph.get('edge_by_hash')
-    assert seg.graph['edge_by_hash'][h1] == signed_edge1
-    # Todo: fix the hash to node mapping for expanded graphs: h2 maps to two
-    #  edges
-    assert seg.graph['edge_by_hash'][h2] == signed_edge3
+    assert signed_edge1 in seg.graph['edge_by_hash'][h1]
+    assert signed_edge2 in seg.graph['edge_by_hash'][h2]
+    assert signed_edge3 in seg.graph['edge_by_hash'][h2]
     assert seg.graph.get('node_by_ns_id')
     assert seg.graph.get('date') == date
     assert len(seg.edges) == 3, len(seg.edges)
@@ -176,10 +175,9 @@ def test_expanded_signed_graph_dump():
 
     # Check signed node graph
     assert sng.graph.get('edge_by_hash')
-    assert sng.graph['edge_by_hash'][h1] == sign_node_edge1
-    # Todo: fix the hash to node mapping for expanded graphs: h2 maps to two
-    #  edges
-    assert sng.graph['edge_by_hash'][h2] == sign_node_edge3
+    assert sign_node_edge1 in sng.graph['edge_by_hash'][h1]
+    assert sign_node_edge2 in sng.graph['edge_by_hash'][h2]
+    assert sign_node_edge3 in sng.graph['edge_by_hash'][h2]
     assert sng.graph.get('node_by_ns_id')
     assert sng.graph.get('date') == date
     assert len(sng.edges) == 3

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -1,27 +1,42 @@
+from datetime import datetime
 import pandas as pd
 from depmap_analysis.network_functions.net_functions import \
     sif_dump_df_to_digraph
 
 # Add input
-hashes = [1234657890, 9876543210]
-bd = {1234657890: 0.685, 9876543210: 0.95}
-src = {1234657890: {'srcA': 2, 'srcB': 5}, 9876543210: {'srcA': 5, 'srcB': 8}}
+h1, h2 = 1234657890, 9876543210
+hashes = [h1, h2]
+bd = [0.685, 0.95]
+src = [{'srcA': 2, 'srcB': 5}, {'srcA': 5, 'srcB': 8}]
 sif = {'agA_name': ['nameX1', 'nameX2'], 'agA_ns': ['nsX1', 'nsX2'],
        'agA_id': ['idX1', 'idX2'], 'agB_name': ['nameY1', 'nameY2'],
        'agB_ns': ['nsY1', 'nsY2'], 'agB_id': ['idY1', 'idY2'],
        'stmt_type': ['Activation', 'Complex'], 'evidence_count': [7, 13],
-       'stmt_hash': hashes}
+       'stmt_hash': hashes, 'source_counts': src, 'belief': bd}
 
 
-def test_sif_df():
+def test_digraph_dump():
     sif_df = pd.DataFrame(sif)
-    idg = sif_dump_df_to_digraph(df=sif_df, strat_ev_dict=src,
-                                 belief_dict=bd, graph_type='digraph',
+    idg = sif_dump_df_to_digraph(df=sif_df,
+                                 date=datetime.utcnow().strftime('%Y-%m-%d'),
+                                 graph_type='digraph',
                                  include_entity_hierarchies=False)
     assert idg.graph.get('edge_by_hash')
-    assert idg.graph['edge_by_hash'][1234657890] == ('nameX1', 'nameY1')
-    assert idg.graph['edge_by_hash'][9876543210] == ('nameX2', 'nameY2')
+    assert idg.graph['edge_by_hash'][h1] == ('nameX1', 'nameY1')
+    assert idg.graph['edge_by_hash'][h2] == ('nameX2', 'nameY2')
     assert idg.edges.get(('nameX1', 'nameY1'))
     assert isinstance(idg.edges[('nameX1', 'nameY1')]['statements'], list)
     assert idg.edges[('nameX1', 'nameY1')]['statements'][0]['stmt_hash'] == \
-           1234657890
+           h1
+
+
+def test_digraph_signed_types_dump():
+    pass
+
+
+def test_signed_graph_dump():
+    pass
+
+
+def test_expanded_signed_graph_dump():
+    pass

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -35,12 +35,14 @@ def test_df_from_dict():
 
 
 def test_digraph_dump():
-    sif_df = pd.DataFrame(sif_dict)
+    sif_df = _get_df()
     idg = sif_dump_df_to_digraph(df=sif_df,
                                  date=datetime.utcnow().strftime('%Y-%m-%d'),
                                  graph_type='digraph',
                                  include_entity_hierarchies=False)
     assert idg.graph.get('edge_by_hash')
+    assert idg.graph.get('date')
+    assert idg.graph.get('node_by_ns_id')
     assert idg.graph['edge_by_hash'][h1] == ('nameX1', 'nameY1')
     assert idg.graph['edge_by_hash'][h2] == ('nameX2', 'nameY2')
     assert idg.edges.get(('nameX1', 'nameY1'))

--- a/depmap_analysis/tests/test_graph_generation.py
+++ b/depmap_analysis/tests/test_graph_generation.py
@@ -24,6 +24,16 @@ sif_dict = {'agA_name': agA_names, 'agA_ns': agA_ns_list,
             'source_counts': src, 'belief': bd}
 
 
+def _get_df():
+    sif_df = pd.DataFrame(sif_dict)
+    return sif_df
+
+
+def test_df_from_dict():
+    df = _get_df()
+    assert len(agA_names) == len(df)
+
+
 def test_digraph_dump():
     sif_df = pd.DataFrame(sif_dict)
     idg = sif_dump_df_to_digraph(df=sif_df,

--- a/depmap_analysis/util/aws.py
+++ b/depmap_analysis/util/aws.py
@@ -7,7 +7,7 @@ from indra.util.aws import get_s3_file_tree, get_s3_client
 from indra_db.managers.dump_manager import Belief, Sif, StatementHashMeshId,\
     SourceCount
 
-dumpers = [Belief, Sif, SourceCount]
+dumpers = [Sif]
 dumpers_alt_name = {SourceCount.name: 'src_counts'}
 
 logger = logging.getLogger(__name__)
@@ -46,19 +46,14 @@ def get_latest_sif_s3(get_mesh_ids=False):
                 necc_keys[n] = k
                 break
     logger.info(f'Latest files: {", ".join([f for f in necc_keys.values()])}')
-    df = load_pickle_from_s3(s3, key=necc_keys[Sif.name],
-                             bucket=DUMPS_BUCKET)
-    sev = load_pickle_from_s3(s3, key=necc_keys[SourceCount.name],
-                              bucket=DUMPS_BUCKET)
-    bd = read_json_from_s3(s3, key=necc_keys[Belief.name],
-                           bucket=DUMPS_BUCKET)
+    df = load_pickle_from_s3(s3, key=necc_keys[Sif.name], bucket=DUMPS_BUCKET)
     if get_mesh_ids:
         mid = load_pickle_from_s3(s3,
                                   key=necc_keys[StatementHashMeshId.name],
                                   bucket=DUMPS_BUCKET)
-        return df, sev, bd, mid
+        return df, mid
 
-    return df, sev, bd
+    return df
 
 
 def load_pickle_from_s3(s3, key, bucket):

--- a/depmap_analysis/util/aws.py
+++ b/depmap_analysis/util/aws.py
@@ -53,7 +53,18 @@ def get_latest_sif_s3(get_mesh_ids=False):
                                   bucket=DUMPS_BUCKET)
         return df, mid
 
-    return df
+
+def _get_date_from_s3_str(s3path: str) -> str:
+    # Checks if truly an s3 path
+    patt = re.compile('s3://bigmech/indra-db/dumps/([0-9\-]+)/(.*)')
+    m = patt.match(s3path)
+    if m is None:
+        raise ValueError(f'Invalid format for s3 path: {s3path}')
+
+    # Split and get second to last directory
+    date_str, fname = m.groups()
+    logger.info(f'Got date {date_str} for {fname}')
+    return date_str
 
 
 def load_pickle_from_s3(s3, key, bucket):


### PR DESCRIPTION
This PR updates how graph dumping is done and updates the S3 storage keys. The new key structure includes the date the Sif dump was made. This date is also added as an extra piece of meta data to the graphs.

Two new graph options are also available:
- `signed-expanded`: allows the user to specify statements types that
- `digraph-signed-types`

Other changes:
- Tests for graph creation are updated and expanded
- Tests for the so called _"famplex edges"_ are added
- hash-to-edge mapping is updated to handle the `signed-expanded` graph by making the entry a set of edges instead of an edge. _Note: this only applies to the `signed-expanded` graph type._

_Note that the code in this PR depends on the existence of the new INDRA DB dumping that includes belief and source counts._