### PR TITLE
Strict intermediates

### DIFF
--- a/depmap_analysis/network_functions/depmap_network_functions.py
+++ b/depmap_analysis/network_functions/depmap_network_functions.py
@@ -2162,3 +2162,27 @@ def down_sampl_size(available_pairs, size_of_matrix, wanted_pairs,
 
     # Get number of rows to sample
     return int(np.ceil(p*L))
+
+
+def get_pairs(corr_z: pd.DataFrame) -> int:
+    """Count the number of extracable pairs from a pandas correlation matrix
+
+    Count the number of pairs that can be looped over from the DataFrame
+    correlation matrix from the upper triangle of the matrix (since the
+    matrix is assumed to be symmetric) with NaN's and potential values on
+    the diagonal ignored.
+
+    Parameters
+    ----------
+    corr_z : pd.DataFrame
+        A DataFrame with correlations obtained from pandas.DataFrame.corr()
+
+    Returns
+    -------
+    int
+        The count of pairs that can be looped over
+    """
+    # Kudos to https://stackoverflow.com/a/45631406/10478812
+    return corr_z.mask(
+        np.triu(np.ones(corr_z.shape)).astype(bool)
+    ).notna().sum().sum()

--- a/depmap_analysis/network_functions/depmap_network_functions.py
+++ b/depmap_analysis/network_functions/depmap_network_functions.py
@@ -2194,7 +2194,7 @@ def get_pairs(corr_z: pd.DataFrame) -> int:
     ma = bm.mask(np.tril(np.ones(bm.shape).astype(bool)), other=0)
 
     # Return sum over full matrix
-    return ma.sum().sum()
+    return int(ma.sum().sum())
 
 
 def get_chunk_size(n_chunks: int, total_items: int) -> int:

--- a/depmap_analysis/network_functions/depmap_network_functions.py
+++ b/depmap_analysis/network_functions/depmap_network_functions.py
@@ -178,7 +178,7 @@ def corr_matrix_to_generator(corrrelation_df_matrix, max_pairs=None):
 
     corr_value_matrix = corr_df_sample.values
     gene_name_array = corr_df_sample.index.values
-    if not isinstance(gene_name_array[0], str):
+    if isinstance(gene_name_array[0], tuple):
         gene_name_array = [n[0] for n in gene_name_array]
     tr_up_indices = np.triu_indices(n=len(corr_value_matrix), k=1)
     # Only get HGNC symbols (first in tuple) since we're gonna compare to
@@ -2186,3 +2186,22 @@ def get_pairs(corr_z: pd.DataFrame) -> int:
     return corr_z.mask(
         np.triu(np.ones(corr_z.shape)).astype(bool)
     ).notna().sum().sum()
+
+
+def get_chunk_size(n_chunks: int, total_items: int) -> int:
+    """Find n such that `(n-1)*n_chunks < total_items <= n*n_chunks`
+
+    Parameters
+    ----------
+    n_chunks : int
+        The number of chunks of iterables wanted
+    total_items : int
+        The total number of items in the original iterable
+
+    Returns
+    -------
+    int
+        Return n in `(n-1)*n_chunks < total_items <= n*n_chunks`
+    """
+    # How many pairs does a chunk need to contain to get chunks_wanted chunks?
+    return max(int(np.ceil(total_items / n_chunks)), 1)

--- a/depmap_analysis/network_functions/depmap_network_functions.py
+++ b/depmap_analysis/network_functions/depmap_network_functions.py
@@ -2165,7 +2165,7 @@ def down_sampl_size(available_pairs, size_of_matrix, wanted_pairs,
 
 
 def get_pairs(corr_z: pd.DataFrame) -> int:
-    """Count the number of extracable pairs from a pandas correlation matrix
+    """Count the number of extractable pairs from a pandas correlation matrix
 
     Count the number of pairs that can be looped over from the DataFrame
     correlation matrix from the upper triangle of the matrix (since the
@@ -2175,17 +2175,26 @@ def get_pairs(corr_z: pd.DataFrame) -> int:
     Parameters
     ----------
     corr_z : pd.DataFrame
-        A DataFrame with correlations obtained from pandas.DataFrame.corr()
+        A DataFrame with correlations obtained from pandas.DataFrame.corr().
+        The DataFrame is assumed to be pre-filtered such that values
+        filtered out are NaN's.
 
     Returns
     -------
     int
         The count of pairs that can be looped over
     """
-    # Kudos to https://stackoverflow.com/a/45631406/10478812
-    return corr_z.mask(
-        np.triu(np.ones(corr_z.shape)).astype(bool)
-    ).notna().sum().sum()
+    # Expect corr_z to be filtered to the values of interest and that the
+    # values that are filtered out are NaN's
+
+    # Map to boolean with NaN => False, else True
+    bm: pd.DataFrame = (~corr_z.isna())
+
+    # Mask lower triangle and diagonal with zeroes
+    ma = bm.mask(np.tril(np.ones(bm.shape).astype(bool)), other=0)
+
+    # Return sum over full matrix
+    return ma.sum().sum()
 
 
 def get_chunk_size(n_chunks: int, total_items: int) -> int:

--- a/depmap_analysis/scripts/depmap_script2.py
+++ b/depmap_analysis/scripts/depmap_script2.py
@@ -52,7 +52,7 @@ from depmap_analysis.util.io_functions import file_opener, \
 from depmap_analysis.network_functions.net_functions import \
     pybel_node_name_mapping
 from depmap_analysis.network_functions.depmap_network_functions import \
-    corr_matrix_to_generator, down_sampl_size, get_pairs
+    corr_matrix_to_generator, down_sampl_size, get_pairs, get_chunk_size
 from depmap_analysis.util.statistics import DepMapExplainer, min_columns, \
     id_columns
 from depmap_analysis.preprocessing import *
@@ -292,7 +292,7 @@ def match_correlations(corr_z: pd.DataFrame,
     with mp.Pool() as pool:
         MAX_SUB = 512
         n_sub = min(kwargs.get('n-chunks', 256), MAX_SUB)
-        chunksize = max(estim_pairs // n_sub, 1)
+        chunksize = get_chunk_size(n_sub, estim_pairs)
 
         # Pick one more so we don't do more than MAX_SUB
         chunksize += 1 if n_sub == MAX_SUB else 0

--- a/depmap_analysis/scripts/depmap_script_expl_funcs.py
+++ b/depmap_analysis/scripts/depmap_script_expl_funcs.py
@@ -280,8 +280,7 @@ def get_sr(s: str, o: str, corr: float, net: Union[DiGraph, MultiDiGraph],
     # Return x_nodes if strict, else if there is anything in union or s_pred
     # or o_pred
     strict = kwargs.get('strict_intermediates', False)
-    if (strict and x_nodes) or \
-            (not strict and x_nodes_union or s_pred or o_pred):
+    if (strict and x_nodes) or (not strict and (s_pred or o_pred)):
         return s, o, (list(s_pred), list(o_pred),
                       list(x_nodes or []), list(x_nodes_union or []))
     else:
@@ -348,8 +347,7 @@ def get_st(s: str, o: str, corr: float, net: Union[DiGraph, MultiDiGraph],
     # Return x_nodes if strict, else if there is anything in union or s_succ
     # or o_succ
     strict = kwargs.get('strict_intermediates', False)
-    if (strict and x_nodes) or \
-            (not strict and x_nodes_union or s_succ or o_succ):
+    if (strict and x_nodes) or (not strict and (s_succ or o_succ)):
         return s, o, (list(s_succ), list(o_succ),
                       list(x_nodes or []), list(x_nodes_union or []))
     else:

--- a/depmap_analysis/scripts/depmap_script_expl_funcs.py
+++ b/depmap_analysis/scripts/depmap_script_expl_funcs.py
@@ -277,8 +277,11 @@ def get_sr(s: str, o: str, corr: float, net: Union[DiGraph, MultiDiGraph],
         x_nodes = x_set
         x_nodes_union = x_set_union
 
-    # Return if there is anything in union, s_pred or o_pred
-    if x_nodes_union or s_pred or o_pred:
+    # Return x_nodes if strict, else if there is anything in union or s_pred
+    # or o_pred
+    strict = kwargs.get('strict_intermediates', False)
+    if (strict and x_nodes) or \
+            (not strict and x_nodes_union or s_pred or o_pred):
         return s, o, (list(s_pred), list(o_pred),
                       list(x_nodes or []), list(x_nodes_union or []))
     else:
@@ -342,8 +345,11 @@ def get_st(s: str, o: str, corr: float, net: Union[DiGraph, MultiDiGraph],
         x_nodes = x_set
         x_nodes_union = x_set_union
 
-    # Return if there is any node in union, s_succ or o_succ
-    if x_nodes_union or s_succ or o_succ:
+    # Return x_nodes if strict, else if there is anything in union or s_succ
+    # or o_succ
+    strict = kwargs.get('strict_intermediates', False)
+    if (strict and x_nodes) or \
+            (not strict and x_nodes_union or s_succ or o_succ):
         return s, o, (list(s_succ), list(o_succ),
                       list(x_nodes or []), list(x_nodes_union or []))
     else:

--- a/depmap_analysis/tests/test_script.py
+++ b/depmap_analysis/tests/test_script.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pandas as pd
+from indra.util import batch_iter
 
-from depmap_analysis.scripts.depmap_script2 import _get_pairs, _down_sample_df
+from depmap_analysis.network_functions.depmap_network_functions import \
+    corr_matrix_to_generator, get_pairs, get_chunk_size
+from depmap_analysis.scripts.depmap_script2 import _down_sample_df
 
 
 def _gen_sym_matrix(size):
@@ -31,14 +34,14 @@ def test_df_pair_calc():
     a.iloc[row, col] = np.nan
     a.iloc[col, row] = np.nan
 
-    n_pairs = _get_pairs(a)
+    n_pairs = get_pairs(a)
     assert n_pairs == int((size**2 - size - 2) / 2)
 
     # Test having some of the diagonal elements gone as well, this should
     # not affect the count since diagonal elements should be ignored
     d = np.random.randint(0, size)
     a.iloc[d, d] = np.nan
-    n_pairs = _get_pairs(a)
+    n_pairs = get_pairs(a)
     assert n_pairs == int((size**2 - size - 2) / 2)
 
 
@@ -58,4 +61,59 @@ def test_down_sampling():
 
     goal_pairs = 10
     a = _down_sample_df(z_corr=a, sample_size=goal_pairs)
-    assert goal_pairs <= _get_pairs(a) <= 1.1 * goal_pairs, _get_pairs(a)
+    assert goal_pairs <= get_pairs(a) <= 1.1 * goal_pairs, get_pairs(a)
+
+
+def test_iterator_slicing():
+    size = 50
+    a = _gen_sym_matrix(size)
+
+    pairs = set()
+    n = 0
+    for n in range(50):
+        k = 0
+        row, col = _get_off_diag_pair(size)
+        while (row, col) in pairs:
+            row, col = _get_off_diag_pair(size)
+            k += 1
+            if k > 1000:
+                print('Too many while iterations, breaking')
+                break
+        if k > 1000:
+            break
+        a.iloc[row, col] = np.nan
+        a.iloc[col, row] = np.nan
+        pairs.add((row, col))
+        pairs.add((col, row))
+
+    pairs_removed = n + 1
+
+    # Assert that we're correct so far
+    assert (size**2 - size - 2*pairs_removed) / 2 == get_pairs(a)
+
+    # Check that the iterator slicing for multiprocessing runs through all
+    # the pairs
+
+    # Get total pairs available
+    total_pairs = get_pairs(a)
+
+    # Chunks wanted
+    chunks_wanted = 10
+
+    chunksize = get_chunk_size(chunks_wanted, total_pairs)
+
+    chunk_iter = batch_iter(iterator=corr_matrix_to_generator(a),
+                            batch_size=chunksize, return_func=list)
+
+    pair_count = 0
+    chunk_ix = 0
+    for chunk_ix, list_of_pairs in enumerate(chunk_iter):
+        pair_count += len([t for t in list_of_pairs if t is not None])
+
+    # Were all pairs looped?
+    assert pair_count == total_pairs, \
+        f'pair_count={pair_count} total_pairs={total_pairs}'
+    # Does the number of loop iterations correspond to the number of chunks
+    # wanted?
+    assert chunk_ix + 1 == chunks_wanted, \
+        f'chunk_ix+1={chunk_ix + 1}, chunks_wanted={chunks_wanted}'


### PR DESCRIPTION
This PR adds the ability to flag for a stricter condition when looking for shared targets and shared regulators in the main Depmap script. With the flag set to `True`, the condition is if the intersection of neighboring nodes exists, while with the flag set to `False`, the condition is if any neighbors exist to `A` _or_ `B`.

Other changes:
- Make the function `get_pairs` public and update its way of calculating the available pairs
- Add a test of the slicing of pairs to test in the main script for multiprocessing