### PR TITLE
Corr loop patch

### DIFF
--- a/depmap_analysis/network_functions/depmap_network_functions.py
+++ b/depmap_analysis/network_functions/depmap_network_functions.py
@@ -165,21 +165,11 @@ def corr_matrix_to_generator(correlation_df_matrix: pd.DataFrame,
             corr_df_sample = correlation_df_matrix
 
         elif max_pairs < all_pairs:
-            n = int(np.floor(np.sqrt(max_pairs))/2 - 1)
-            corr_df_sample = correlation_df_matrix.sample(
-                n, axis=0).sample(n, axis=1)
-
-            # Increase sample until number of extractable pairs exceed
-            # max_pairs
-            n_pairs = get_pairs(corr_df_sample)
-            while n_pairs <= max_pairs:
-                n += 1
-                corr_df_sample = \
-                    correlation_df_matrix.sample(n, axis=0).sample(n, axis=1)
-                n_pairs = get_pairs(corr_df_sample)
+            corr_df_sample = down_sample_df(correlation_df_matrix, max_pairs)
 
             logger.info(f'Created a random sample of the correlation matrix '
-                        f'with {n_pairs} extractable correlation pairs.')
+                        f'with {get_pairs(corr_df_sample)} extractable '
+                        f'correlation pairs.')
 
     # max_pairs == None: no sampling, get all non-NaN correlations;
     else:

--- a/depmap_analysis/network_functions/depmap_network_functions.py
+++ b/depmap_analysis/network_functions/depmap_network_functions.py
@@ -2223,3 +2223,36 @@ def get_chunk_size(n_chunks: int, total_items: int) -> int:
     """
     # How many pairs does a chunk need to contain to get chunks_wanted chunks?
     return max(int(np.ceil(total_items / n_chunks)), 1)
+
+
+def down_sample_df(z_corr: pd.DataFrame, sample_size: int) -> pd.DataFrame:
+    """Given a square data frame, down sample it to sample_size or close to it
+
+    Parameters
+    ----------
+    z_corr : pd.DataFrame
+        DataFrame to down sample
+    sample_size
+        Goal number of extractable pairs
+
+    Returns
+    -------
+    pd.DataFrame
+        The down sampled data frame
+    """
+    # Do small initial downsampling
+    row_samples = len(z_corr) - 1
+    n_pairs = get_pairs(corr_z=z_corr)
+    while n_pairs > int(1.1 * sample_size):
+        logger.info(f'Down sampling from {n_pairs}')
+        z_corr = z_corr.sample(row_samples, axis=0)
+        z_corr = z_corr.filter(list(z_corr.index), axis=1)
+
+        # Update n_pairs and row_samples
+        n_pairs = get_pairs(corr_z=z_corr)
+        mm = max(row_samples - int(np.ceil(0.05 * row_samples))
+                 if n_pairs - sample_size < np.ceil(0.1 * sample_size)
+                 else down_sampl_size(n_pairs, len(z_corr), sample_size),
+                 1)
+        row_samples = row_samples - 1 if mm >= row_samples else mm
+    return z_corr

--- a/depmap_analysis/network_functions/depmap_network_functions.py
+++ b/depmap_analysis/network_functions/depmap_network_functions.py
@@ -2134,10 +2134,7 @@ def down_sampl_size(available_pairs, size_of_matrix, wanted_pairs,
     Parameters
     ----------
     available_pairs : int
-        Number of pairs in correlation matrix as counted by
-        corr_z.mask(
-            np.triu(np.ones(corr_z.shape)).astype(bool)
-        ).notna().sum().sum()
+        Number of pairs in correlation matrix as counted by `get_pairs()`
     size_of_matrix : int
         The number of rows/columns of the correlation matrix as counted by
         len(corr)

--- a/depmap_analysis/network_functions/depmap_network_functions.py
+++ b/depmap_analysis/network_functions/depmap_network_functions.py
@@ -181,7 +181,8 @@ def corr_matrix_to_generator(correlation_df_matrix: pd.DataFrame,
         gene_name_array = [n[0] for n in gene_name_array]
     if permute:
         return ((a, b, corr_df_sample.loc[a, b])
-                for a, b in itt.permutations(gene_name_array, r=2))
+                for a, b in itt.permutations(gene_name_array, r=2)
+                if not np.isnan(corr_df_sample.loc[a, b]))
     else:
         tr_up_indices = np.triu_indices(n=len(corr_value_matrix), k=1)
         return ((gene_name_array[i], gene_name_array[j],

--- a/depmap_analysis/network_functions/depmap_network_functions.py
+++ b/depmap_analysis/network_functions/depmap_network_functions.py
@@ -126,14 +126,14 @@ def csv_file_to_generator(fname, column_list):
     return (tuple(line[1]) for line in pair_corr_file.iterrows())
 
 
-def corr_matrix_to_generator(corrrelation_df_matrix, max_pairs=None):
+def corr_matrix_to_generator(correlation_df_matrix, max_pairs=None):
     """Return a tuple generator given a correlation matrix
     
     The function takes a correlation matrix and returns a consumable tuple 
     generator object. Once consumed, the object is exhausted and a new
     generator needs to be produced.
 
-    corrrelation_df_matrix : pandas.DataFrame
+    correlation_df_matrix : pd.DataFrame
         A correlation matrix as a pandas dataframe
 
     Returns
@@ -143,7 +143,7 @@ def corr_matrix_to_generator(corrrelation_df_matrix, max_pairs=None):
     """
     # Sample at random: get a random sample of the correlation matrix that has
     # enough non-nan values to exhaustively generate at least max_pair
-    all_pairs = corrrelation_df_matrix.notna().sum().sum()
+    all_pairs = correlation_df_matrix.notna().sum().sum()
     if all_pairs == 0:
         logger.warning('Correlation matrix is empty')
         raise ValueError('Script aborted due to empty correlation matrix')
@@ -154,18 +154,18 @@ def corr_matrix_to_generator(corrrelation_df_matrix, max_pairs=None):
             logger.info('The requested number of correlation pairs is '
                             'larger than the available number of pairs. '
                             'Resetting `max_pairs` to %i' % all_pairs)
-            corr_df_sample = corrrelation_df_matrix
+            corr_df_sample = correlation_df_matrix
 
         elif max_pairs < all_pairs:
             n = int(np.floor(np.sqrt(max_pairs))/2 - 1)
-            corr_df_sample = corrrelation_df_matrix.sample(
+            corr_df_sample = correlation_df_matrix.sample(
                 n, axis=0).sample(n, axis=1)
 
             # Increase sample until number of extractable pairs exceed
             # max_pairs
             while corr_df_sample.notna().sum().sum() <= max_pairs:
                 n += 1
-                corr_df_sample = corrrelation_df_matrix.sample(
+                corr_df_sample = correlation_df_matrix.sample(
                     n, axis=0).sample(n, axis=1)
 
         logger.info('Created a random sample of the correlation matrix '
@@ -174,7 +174,7 @@ def corr_matrix_to_generator(corrrelation_df_matrix, max_pairs=None):
 
     # max_pairs == None: no sampling, get all non-NaN correlations;
     else:
-        corr_df_sample = corrrelation_df_matrix
+        corr_df_sample = correlation_df_matrix
 
     corr_value_matrix = corr_df_sample.values
     gene_name_array = corr_df_sample.index.values
@@ -1067,7 +1067,7 @@ def get_combined_correlations(dict_of_data_sets, filter_settings,
         # Generate correlation dict
         corr_dict = get_gene_gene_corr_dict(
             tuple_generator=corr_matrix_to_generator(
-                corrrelation_df_matrix=filtered_corr_matrix,
+                correlation_df_matrix=filtered_corr_matrix,
                 max_pairs=dataset_dict['max_pairs']
             )
         )

--- a/depmap_analysis/scripts/depmap_script2.py
+++ b/depmap_analysis/scripts/depmap_script2.py
@@ -477,7 +477,11 @@ def main(indra_net: Union[nx.DiGraph, nx.MultiDiGraph],
         intersection of nodes up- or downstream of A, B for shared
         regulators and shared targets. Default: False.
     reactome_dict : Dict[str, Any]
-        Mapping from gene UP ID to its associated reactome pathways
+        A dict containing two dicts:
+        - Key 'uniprot_mapping': a dict containing a mapping from gene UP ID
+          to its associated reactome pathways
+        - Key 'pathid_name_mapping': a dict containing a mapping from a
+          reactome path id to human readable name
     permute_corrs :  bool
         If True, check all combinations of off-diagonal values from the
         correlation matrix, i.e. check both (a, b) and (b, a). Default: False.

--- a/depmap_analysis/scripts/depmap_script2.py
+++ b/depmap_analysis/scripts/depmap_script2.py
@@ -492,8 +492,9 @@ def main(indra_net: Union[nx.DiGraph, nx.MultiDiGraph],
         >>> from depmap_analysis.scripts.depmap_script2 import mito_file
         >>> from depmap_analysis.preprocessing import get_mitocarta_info
         >>> apriori_mapping = get_mitocarta_info(mito_file)
-        then pass `apriori_mapping` to `apriori_explained` when calling this
-        funciton.
+        then pass `apriori_mapping` as `apriori_explained` when calling this
+        function:
+        >>> main(apriori_explained=apriori_mapping, ...)
     allowed_ns : Optional[List[str]]
         A list of allowed name spaces for explanations involving
         intermediary nodes. Default: Any namespace.

--- a/depmap_analysis/scripts/depmap_script2.py
+++ b/depmap_analysis/scripts/depmap_script2.py
@@ -454,9 +454,23 @@ def main(indra_net: Union[nx.DiGraph, nx.MultiDiGraph],
         File paths to raw correlation data (before z-score conversion)
         containing hdf compressed correlation data. These files contain the
         result of running `raw_df.corr()`.
-    expl_funcs : Optional[Iterable[str]]
+    expl_funcs : Optional[List[str]]
         Provide a list of explanation functions to apply. Default: All
-        functions are applied.
+        functions are applied. Currently available functions:
+        - 'expl_ab': Explain pair by checking for an edge between a and b
+        - 'expl_ba': Explain pair by checking for an edge between b and a
+        - 'expl_axb': Explain pair by looking for intermediate nodes
+          connecting a to b
+        - 'expl_bxa': Explain pair by looking for intermediate nodes
+          connecting b to a
+        - 'get_sr': Explain pair by finding common upstream nodes
+        - 'get_st': Explain pair by finding common downstream nodes
+        - 'get_sd': Explain pair by finding common downstream nodes two
+          edges from s and o
+        - 'find_cp': Explain pair by looking for ontological parents
+        - 'apriori_explained': Map entities to a-priori explanations
+        - 'common_reactome_paths': Explain pair by matching common reactome
+          pathways
     pb_node_mapping : Optional[Union[Dict, Set[Any]]]
         If graph type is "pybel", use this argument to provide a mapping
         from HGNC symbols to pybel nodes in the pybel model

--- a/depmap_analysis/scripts/depmap_script2.py
+++ b/depmap_analysis/scripts/depmap_script2.py
@@ -76,7 +76,7 @@ def _match_correlation_body(corr_iter: Generator[Tuple[str, str, float],
                             stats_columns: Tuple[str],
                             expl_cols: Tuple[str],
                             bool_columns: Tuple[str],
-                            expl_mapping: Optional[Dict[str, str]],
+                            apriori_explained: Optional[Dict[str, str]],
                             _type: str,
                             allowed_ns: Optional[Set[str]] = None,
                             allowed_sources: Optional[Set[str]] = None,
@@ -110,8 +110,8 @@ def _match_correlation_body(corr_iter: Generator[Tuple[str, str, float],
             options['ns_set'] = allowed_ns
         if allowed_sources:
             options['src_set'] = allowed_sources
-        if expl_mapping:
-            options['expl_mapping'] = expl_mapping
+        if apriori_explained:
+            options['apriori_explained'] = apriori_explained
 
         for tup in corr_iter:
             # Break loop when batch_iter reaches None padding
@@ -275,7 +275,7 @@ def match_correlations(corr_z: pd.DataFrame,
     bool_columns = ('not_in_graph', 'explained') + tuple(expl_types.keys())
     stats_columns = id_columns + bool_columns
     expl_cols = expl_columns
-    expl_mapping = kwargs.get('expl_mapping', {})
+    apriori_explained = kwargs.get('apriori_explained', {})
 
     _type = kwargs.get('graph_type', 'unsigned')
     logger.info(f'Doing correlation matching with {_type} graph')
@@ -336,7 +336,7 @@ def match_correlations(corr_z: pd.DataFrame,
                                  stats_columns,
                                  expl_cols,
                                  bool_columns,
-                                 expl_mapping,
+                                 apriori_explained,
                                  _type,
                                  allowed_ns,
                                  allowed_sources,
@@ -401,7 +401,6 @@ def main(indra_net: Union[nx.DiGraph, nx.MultiDiGraph],
          expl_funcs: Optional[List[str]] = None,
          pb_node_mapping: Optional[Dict[str, Set]] = None,
          n_chunks: Optional[int] = 256,
-         expl_mapping: Optional[Dict[str, str]] = None,
          is_a_part_of: Optional[List[str]] = None,
          immediate_only: Optional[bool] = False,
          return_unexplained: Optional[bool] = False,
@@ -477,9 +476,6 @@ def main(indra_net: Union[nx.DiGraph, nx.MultiDiGraph],
     n_chunks : Optional[int]
         How many chunks to split the data into in the multiprocessing part
         of the script
-    expl_mapping : Optional[Dict[str, str]]
-        A mapping from entity to a string with information about the entity
-        that explains why it is considered 'explained'
     is_a_part_of : Optional[Iterable]
         A set of identifiers to look for when applying the common parent
         explanation between a pair of correlating nodes.
@@ -566,10 +562,10 @@ def main(indra_net: Union[nx.DiGraph, nx.MultiDiGraph],
         raise ValueError('Must provide either z_score XOR either of raw_data '
                          'or raw_corr')
 
-    if expl_mapping:
-        run_options['expl_mapping'] = expl_mapping
+    if apriori_explained:
+        run_options['apriori_explained'] = apriori_explained
         logger.info(f'Using explained set with '
-                    f'{len(expl_mapping)} genes')
+                    f'{len(apriori_explained)} entities')
 
     outname = outname if outname.endswith('.pkl') else \
         outname + '.pkl'
@@ -952,7 +948,7 @@ if __name__ == '__main__':
                                  '"description" for explanation why the '
                                  'entity is explained.') \
                     from err
-        arg_dict['expl_mapping'] = expl_map
+        arg_dict['apriori_explained'] = expl_map
 
     if args.reactome_dict:
         up2path, _, pathid2pathname = file_opener(args.reactome_dict)

--- a/depmap_analysis/scripts/depmap_script2.py
+++ b/depmap_analysis/scripts/depmap_script2.py
@@ -711,6 +711,7 @@ def main(indra_net: Union[nx.DiGraph, nx.MultiDiGraph],
         dump_it_to_pickle(fname=outpath.absolute().resolve().as_posix(),
                           pyobj=explanations, overwrite=overwrite)
     logger.info('Script finished')
+    explanations.summarize()
 
 
 if __name__ == '__main__':

--- a/depmap_analysis/scripts/depmap_script_expl_funcs.py
+++ b/depmap_analysis/scripts/depmap_script_expl_funcs.py
@@ -39,7 +39,7 @@ class FunctionRegistrationError(Exception):
 def apriori_explained(s: str, o: str, corr: float,
                       net: Union[DiGraph, MultiDiGraph], _type: str, **kwargs)\
         -> Tuple[str, str, bool, Union[str, None]]:
-    """A mock function that is used for a-priori explained pairs
+    """Map entities to a-priori explanations
 
     Parameters
     ----------

--- a/depmap_analysis/scripts/depmap_script_expl_funcs.py
+++ b/depmap_analysis/scripts/depmap_script_expl_funcs.py
@@ -58,10 +58,10 @@ def apriori_explained(s: str, o: str, corr: float,
     -------
     Tuple[str, str, bool, Union[str, None]]
         If explained, the tuple (s, o, explained, explanation) is returned,
-        where `explained` is a flags the truthyness of the explanation and
+        where `explained` flags the truthyness of the explanation and
         `explanation` is a string mapped from the subject and/or object.
     """
-    expl_mapping: Union[Dict[str, str], None] = kwargs.get('expl_mapping')
+    expl_mapping: Union[Dict[str, str], None] = kwargs.get('apriori_explained')
     if expl_mapping is None:
         return s, o, False, None
 

--- a/depmap_analysis/tests/test_script.py
+++ b/depmap_analysis/tests/test_script.py
@@ -128,6 +128,31 @@ def test_iterator_slicing():
     assert chunk_ix + 1 == chunks_wanted, \
         f'chunk_ix+1={chunk_ix + 1}, chunks_wanted={chunks_wanted}'
 
+    # Redo the same with permute==True
+    # Get total pairs available
+    total_pairs_permute = get_pairs(a, permute=True)
+
+    # Chunks wanted
+    chunks_wanted = 10
+
+    chunksize = get_chunk_size(chunks_wanted, total_pairs_permute)
+
+    chunk_iter = batch_iter(iterator=corr_matrix_to_generator(a, permute=True),
+                            batch_size=chunksize, return_func=list)
+
+    pair_count = 0
+    chunk_ix = 0
+    for chunk_ix, list_of_pairs in enumerate(chunk_iter):
+        pair_count += len([t for t in list_of_pairs if t is not None])
+
+    # Were all pairs looped?
+    assert pair_count == total_pairs_permute, \
+        f'pair_count={pair_count} total_pairs={total_pairs_permute}'
+    # Does the number of loop iterations correspond to the number of chunks
+    # wanted?
+    assert chunk_ix + 1 == chunks_wanted, \
+        f'chunk_ix+1={chunk_ix + 1}, chunks_wanted={chunks_wanted}'
+
 
 def test_depmap_script():
     reactome_dict = file_opener(

--- a/depmap_analysis/tests/test_script.py
+++ b/depmap_analysis/tests/test_script.py
@@ -80,7 +80,7 @@ def test_iterator_slicing():
 
     pairs = set()
     n = 0
-    for n in range(50):
+    for n in range(size):
         k = 0
         row, col = _get_off_diag_pair(size)
         while (row, col) in pairs:

--- a/depmap_analysis/tests/test_script.py
+++ b/depmap_analysis/tests/test_script.py
@@ -8,9 +8,9 @@ from indra.util import batch_iter
 from indra.databases.hgnc_client import uniprot_ids, hgnc_names
 from depmap_analysis.util.io_functions import file_opener
 from depmap_analysis.network_functions.depmap_network_functions import \
-    corr_matrix_to_generator, get_pairs, get_chunk_size
-from depmap_analysis.scripts.depmap_script2 import _down_sample_df, \
-    _match_correlation_body, expl_columns, id_columns
+    corr_matrix_to_generator, get_pairs, get_chunk_size, down_sample_df
+from depmap_analysis.scripts.depmap_script2 import _match_correlation_body, \
+    expl_columns, id_columns
 from depmap_analysis.scripts.depmap_script_expl_funcs import *
 from . import *
 
@@ -70,7 +70,7 @@ def test_down_sampling():
         pairs.add((col, row))
 
     goal_pairs = 10
-    a = _down_sample_df(z_corr=a, sample_size=goal_pairs)
+    a = down_sample_df(z_corr=a, sample_size=goal_pairs)
     assert goal_pairs <= get_pairs(a) <= 1.1 * goal_pairs, get_pairs(a)
 
 


### PR DESCRIPTION
This PR adds the capability of the depmap script to loop both `(a, b)` and `(b, a)`, provided the pair is off-diagonal, i.e. `a != b`. This is useful when the correlation matrix is sliced in a particular fashion to make it asymmetric e.g. when wanting to check a certain subset of genes vs all other genes.

A test was extended to test this use case.