### PR TITLE
Post processing update

### DIFF
--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -540,7 +540,8 @@ def _get_interm_corr_stats(a: str, b: str, y_set: Union[List[str], Set[str]],
                 continue
             ay_corr = z_corr.loc[y, a]
             by_corr = z_corr.loc[y, b]
-            if np.isnan(ay_corr) or np.isnan(by_corr):
+            if global_vars['verbose'] and \
+                    (np.isnan(ay_corr) or np.isnan(by_corr)):
                 # Is there a more efficient way of doing this?
                 logger.info(
                     f'NaN correlations for subj-y ({str(a)}-{str(y)}) or '

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -107,7 +107,7 @@ class GlobalVars(object):
         return set(global_vars.keys())
 
     @staticmethod
-    def assert_global_vars(varnames):
+    def assert_global_vars(varnames: Set[str]):
         """
 
         varnames : set(str)
@@ -123,13 +123,14 @@ class GlobalVars(object):
     @staticmethod
     def assert_vars():
         """Same as assert_global_vars but with the shared array as well"""
-        df_exists = global_vars.get('expl_df', False) is not False
+        expl_df_exists = global_vars.get('expl_df', False) is not False
+        stats_df_exists = global_vars.get('stats_df', False) is not False
         z_cm_exists = global_vars.get('z_cm', False) is not False
         reactome_exists = global_vars.get('reactome', False) is not False
         ssize_exists = global_vars.get('subset_size', False) is not False
         shared_ar_exists = bool(len(list_of_genes[:]))
-        return df_exists and z_cm_exists and reactome_exists and \
-            ssize_exists and shared_ar_exists
+        return expl_df_exists and stats_df_exists and z_cm_exists and \
+               reactome_exists and ssize_exists and shared_ar_exists
 
 
 # ToDo: make one work submitting function as a wrapper and provide the inner

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -408,8 +408,8 @@ def get_interm_corr_stats_x(subj: str, obj: str, z_corr: pd.DataFrame,
         # Data is in a 4-tuple for shared targets:
         # subj successors, obj predecessors, x intersection, x union
         # For a-x-b, b-x-a the data is not nested
-        x_iter = path_row['expl data'][2] if \
-            path_row['expl_type'] == st_colname else path_row['expl data']
+        x_iter = path_row['expl_data'][2] if \
+            path_row['expl_type'] == st_colname else path_row['expl_data']
         x_names = \
             [x.name if isinstance(x, CentralDogma) else x for
              x in x_iter if x not in (subj, obj)]
@@ -458,8 +458,8 @@ def get_filtered_corr_stats_x(subj: str, obj: str, z_corr: pd.DataFrame,
             # Data is in a 4-tuple for shared targets:
             # subj successors, obj predecessors, x intersection, x union
             # For a-x-b, b-x-a the data is not nested
-            x_iter = path_row['expl data'][2] if \
-                path_row['expl_type'] == st_colname else path_row['expl data']
+            x_iter = path_row['expl_data'][2] if \
+                path_row['expl_type'] == st_colname else path_row['expl_data']
             x_names = \
                 [x.name if isinstance(x, CentralDogma) else x for
                  x in x_iter if x not in (subj, obj)]

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -570,13 +570,13 @@ def _get_interm_corr_stats(a: str, b: str, y_set: Union[List[str], Set[str]],
                 continue
             ay_corr = z_corr.loc[y, a]
             by_corr = z_corr.loc[y, b]
-            if global_vars['verbose'] and \
-                    (np.isnan(ay_corr) or np.isnan(by_corr)):
+            if np.isnan(ay_corr) or np.isnan(by_corr):
+                if global_vars['verbose']:
+                    logger.info(
+                        f'NaN correlations for subj-y ({str(a)}-{str(y)}) or '
+                        f'obj-y ({str(b)}-{str(y)})'
+                    )
                 # Is there a more efficient way of doing this?
-                logger.info(
-                    f'NaN correlations for subj-y ({str(a)}-{str(y)}) or '
-                    f'obj-y ({str(b)}-{str(y)})'
-                )
                 c.update('y_corr_none')
                 continue
 

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -1,5 +1,6 @@
 from time import time
 from ctypes import c_wchar_p
+from typing import Union, Set, List, Tuple, Dict
 from datetime import datetime
 from collections import Counter
 from multiprocessing import Pool, cpu_count, Array, current_process
@@ -7,12 +8,13 @@ import logging
 import random
 
 import numpy as np
+import pandas as pd
 from pybel.dsl.node_classes import CentralDogma
 
 from depmap_analysis.scripts.depmap_script_expl_funcs import axb_colname, \
     bxa_colname, ab_colname, ba_colname, st_colname
 from indra.util.multiprocessing_traceback import WrapException
-from indra.databases.hgnc_client import get_current_hgnc_id, get_uniprot_id,\
+from indra.databases.hgnc_client import get_current_hgnc_id, get_uniprot_id, \
     uniprot_ids, get_hgnc_name
 
 logger = logging.getLogger(__name__)

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -275,10 +275,10 @@ def get_corr_stats_mp(so_pairs, max_proc=cpu_count(),
         results.all_reactome_corrs += done_res['all_reactome_corrs']
         # Var name: reactome_avg_corrs; Dict key: reactome_avg_corrs
         results.reactome_avg_corrs += done_res['reactome_avg_corrs']
-        # Var name: axb_filtered_avg_corrs; Dict key: axb_filtered_avg_corrs
-        results.all_x_filtered_corrs += done_res['axb_filtered_avg_corrs']
         # Var name: all_axb_filtered_corrs; Dict key: all_axb_filtered_corrs
-        results.avg_x_filtered_corrs += done_res['all_axb_filtered_corrs']
+        results.all_x_filtered_corrs += done_res['all_axb_filtered_corrs']
+        # Var name: axb_filtered_avg_corrs; Dict key: axb_filtered_avg_corrs
+        results.avg_x_filtered_corrs += done_res['axb_filtered_avg_corrs']
     return results
 
 

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -60,6 +60,8 @@ class Results(BaseModel):
     top_x_corrs: List[Tuple[str, str, float]] = []
     all_azb_corrs: List[float] = []
     azb_avg_corrs: List[float] = []
+    all_azfb_corrs: List[float] = []  # Background for filtered A,B
+    azfb_avg_corrs: List[float] = []
     all_reactome_corrs: List[float] = []
     reactome_avg_corrs: List[float] = []
     all_x_filtered_corrs: List[float] = []
@@ -300,6 +302,10 @@ def get_corr_stats(so_pairs, run_single_proc: bool = False) \
         axb_filtered_avg_corrs = []
         all_axb_filtered_corrs = []
 
+        # Sample filtered background data per pair
+        azfb_avg_corrs = []
+        all_azfb_corrs = []
+
         # Sample background data per pair
         azb_avg_corrs = []
         all_azb_corrs = []
@@ -332,8 +338,16 @@ def get_corr_stats(so_pairs, run_single_proc: bool = False) \
             all_axb_filtered_corrs += axb_filt_corrs
             counter['xf_skip'] += xf_len - len(avg_xf_corrs_per_ab)
 
-            # Get z values
+            # Get z values for background sampling
             z_iter = np.random.choice(list_of_genes[:], chunk_size, False)
+
+            # Get background for filtered A, B
+            avg_zf_corrs_per_ab, azfb_corrs = \
+                get_interm_corr_stats_zf(subj, obj, z_iter, z_corr, expl_df,
+                                         stats_df)
+            azfb_avg_corrs += avg_zf_corrs_per_ab
+            all_azfb_corrs += azfb_corrs
+
             avg_z_corrs_per_ab, azb_corrs = \
                 get_interm_corr_stats_z(subj, obj, z_iter, z_corr)
             azb_avg_corrs += avg_z_corrs_per_ab
@@ -349,8 +363,9 @@ def get_corr_stats(so_pairs, run_single_proc: bool = False) \
                 counter['r_skip'] += r_len - len(avg_reactome_corrs_per_ab)
 
         assert_list = [all_axb_corrs, axb_avg_corrs, top_axb_corrs,
-                       all_azb_corrs, azb_avg_corrs, axb_filtered_avg_corrs,
-                       all_axb_filtered_corrs]
+                       all_azb_corrs, azb_avg_corrs,
+                       azfb_avg_corrs, all_azfb_corrs,
+                       axb_filtered_avg_corrs, all_axb_filtered_corrs]
         if reactome:
             assert_list += [all_reactome_corrs, reactome_avg_corrs]
         try:
@@ -364,6 +379,8 @@ def get_corr_stats(so_pairs, run_single_proc: bool = False) \
                 f'top_axb_corrs: {len(top_axb_corrs)}, '
                 f'all_azb_corrs: {len(all_azb_corrs)}, '
                 f'azb_avg_corrs: {len(azb_avg_corrs)}, '
+                f'azfb_avg_corrs: {len(azfb_avg_corrs)}, '
+                f'all_azfb_corrs: {len(all_azfb_corrs)}, '
                 f'all_reactome_corrs (only if provided):'
                 f' {len(all_reactome_corrs)}, '
                 f'reactome_avg_corrs (only if provided):'

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -437,38 +437,6 @@ def get_interm_corr_stats_x(subj: str, obj: str, z_corr: pd.DataFrame,
     return _get_interm_corr_stats(subj, obj, x_set, z_corr), len(x_set)
 
 
-def get_filtered_corr_stats_x(subj: str, obj: str, z_corr: pd.DataFrame,
-                              expl_df: pd.DataFrame, stats_df: pd.DataFrame) \
-        -> Tuple[Tuple[List[float], List[float]], int]:
-    """Wrapper to get the a-x-b correlation data from some a-x-b explanations
-
-    This function does exactly the same data extraction as
-    get_interm_corr_stats_x, but filters out those explanations that don't
-    pass the filter
-
-    Parameters
-    ----------
-    subj : str
-        The entity corresponding to A in A,B
-    obj : str
-        The entity corresponding to B in A,B
-    z_corr : pd.DataFrame
-        The correlation dataframe used to produce the input data in expl_df
-        and stats_df
-    expl_df : pd.DataFrame
-        The explanation data frame from the input data
-    stats_df : pd.DataFrame
-        The statistics data frame from the input data
-
-    Returns
-    -------
-    Tuple[Tuple[List[float], List[float]], int]
-    """
-    if _check_interesting(subj, obj, expl_df, stats_df):
-        return get_interm_corr_stats_x(subj, obj, z_corr, expl_df)
-    return ([], []), 0
-
-
 def _check_interesting(subj: str, obj: str, expl_df: pd.DataFrame,
                        stats_df: pd.DataFrame) -> bool:
     """Filter the pair to: not direct, not explained by reactome or apriori
@@ -504,6 +472,74 @@ def _check_interesting(subj: str, obj: str, expl_df: pd.DataFrame,
 
     return (axb or bxa or st) and \
         not ab and not ba and not react and not apriori
+
+
+def get_filtered_corr_stats_x(subj: str, obj: str, z_corr: pd.DataFrame,
+                              expl_df: pd.DataFrame, stats_df: pd.DataFrame) \
+        -> Tuple[Tuple[List[float], List[float]], int]:
+    """Wrapper to get the a-x-b correlation data from some a-x-b explanations
+
+    This function does exactly the same data extraction as
+    get_interm_corr_stats_x, but filters out those explanations that don't
+    pass the filter
+
+    Parameters
+    ----------
+    subj : str
+        The entity corresponding to A in A,B
+    obj : str
+        The entity corresponding to B in A,B
+    z_corr : pd.DataFrame
+        The correlation dataframe used to produce the input data in expl_df
+        and stats_df
+    expl_df : pd.DataFrame
+        The explanation data frame from the input data
+    stats_df : pd.DataFrame
+        The statistics data frame from the input data
+
+    Returns
+    -------
+    Tuple[Tuple[List[float], List[float]], int]
+    """
+    if _check_interesting(subj, obj, expl_df, stats_df):
+        return get_interm_corr_stats_x(subj, obj, z_corr, expl_df)
+    return ([], []), 0
+
+
+def get_interm_corr_stats_zf(subj: str, obj: str, z_set: List[str],
+                             z_corr: pd.DataFrame, expl_df: pd.DataFrame,
+                             stats_df: pd.DataFrame) \
+        -> Tuple[List[float], List[float]]:
+    """Get correlation data from pairs that pass the filter
+
+    This function does the same data extraction as get_interm_corr_stats_z,
+    but skips A, B pairs that don't pass the filter.
+
+    Parameters
+    ----------
+    subj : str
+        The entity corresponding to A in A,B
+    obj : str
+        The entity corresponding to B in A,B
+    z_set : List[str]
+        A list of randomly sampled intermediate entities to get the a-z,
+        z-b correlations from
+    z_corr : pd.DataFrame
+        The correlation dataframe used to produce the input data in expl_df
+        and stats_df
+    expl_df : pd.DataFrame
+        The explanation data frame from the input data
+    stats_df : pd.DataFrame
+        The statistics data frame from the input data
+
+    Returns
+    -------
+    Tuple[List[str], List[str]]
+    """
+    if _check_interesting(subj, obj, expl_df, stats_df):
+        return get_interm_corr_stats_z(subj, obj, z_set, z_corr)
+    return [], []
+
 
 
 def get_interm_corr_stats_z(subj, obj, z_set, z_corr) \

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -390,8 +390,8 @@ def get_corr_stats(so_pairs, run_single_proc: bool = False) \
                 f' {len(all_reactome_corrs)}, '
                 f'reactome_avg_corrs (only if provided):'
                 f' {len(reactome_avg_corrs)}, '
-                f'axb_filtered_avg_corrs: {len(axb_filtered_avg_corrs)}'
-                f'all_axb_filtered_corrs: {len(all_axb_filtered_corrs)}'
+                f'axb_filtered_avg_corrs: {len(axb_filtered_avg_corrs)} '
+                f'all_axb_filtered_corrs: {len(all_axb_filtered_corrs)} '
             ) from exc
 
         logger.info('Counting skips...')

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -254,24 +254,27 @@ def get_corr_stats_mp(so_pairs, max_proc=cpu_count(),
     logger.info(f'Assembling {len(global_results)} results')
     results = Results()
     for done_res in global_results:
-        # Var name: all_x_corrs; Dict key: 'all_axb_corrs'
+        # axb in network
         results.all_x_corrs += done_res['all_axb_corrs']
-        # Var name: avg_x_corrs; Dict key: axb_avg_corrs
         results.avg_x_corrs += done_res['axb_avg_corrs']
-        # Var name: top_x_corrs; Dict key: top_axb_corrs
         results.top_x_corrs += done_res['top_axb_corrs']
-        # Var name: all_azb_corrs; Dict key: all_azb_corrs
+
+        # Background
         results.all_azb_corrs += done_res['all_azb_corrs']
-        # Var name: azb_avg_corrs; Dict key: azb_avg_corrs
         results.azb_avg_corrs += done_res['azb_avg_corrs']
-        # Var name: all_reactome_corrs; Dict key: all_reactome_corrs
+
+        # Reactome "bag-of-genes" data
         results.all_reactome_corrs += done_res['all_reactome_corrs']
-        # Var name: reactome_avg_corrs; Dict key: reactome_avg_corrs
         results.reactome_avg_corrs += done_res['reactome_avg_corrs']
-        # Var name: all_axb_filtered_corrs; Dict key: all_axb_filtered_corrs
+
+        # Filtered axb in graph
         results.all_x_filtered_corrs += done_res['all_axb_filtered_corrs']
-        # Var name: axb_filtered_avg_corrs; Dict key: axb_filtered_avg_corrs
         results.avg_x_filtered_corrs += done_res['axb_filtered_avg_corrs']
+
+        # Filtered background
+        results.all_azfb_corrs += done_res['all_azfb_corrs']
+        results.azfb_avg_corrs += done_res['azfb_avg_corrs']
+
     return results
 
 
@@ -283,6 +286,7 @@ def get_corr_stats_linearly(so_pairs):
 
 def get_corr_stats(so_pairs, run_single_proc: bool = False) \
         -> Dict[str, List[float]]:
+    # ToDo: Switch to numpy arrays
     try:
         global list_of_genes
         expl_df = global_vars['expl_df']
@@ -348,6 +352,7 @@ def get_corr_stats(so_pairs, run_single_proc: bool = False) \
             azfb_avg_corrs += avg_zf_corrs_per_ab
             all_azfb_corrs += azfb_corrs
 
+            # Get unfiltered background
             avg_z_corrs_per_ab, azb_corrs = \
                 get_interm_corr_stats_z(subj, obj, z_iter, z_corr)
             azb_avg_corrs += avg_z_corrs_per_ab
@@ -377,10 +382,10 @@ def get_corr_stats(so_pairs, run_single_proc: bool = False) \
                 f'Stats: all_axb_corrs: {len(all_axb_corrs)}, '
                 f'axb_avg_corrs: {len(axb_avg_corrs)}, '
                 f'top_axb_corrs: {len(top_axb_corrs)}, '
-                f'all_azb_corrs: {len(all_azb_corrs)}, '
-                f'azb_avg_corrs: {len(azb_avg_corrs)}, '
                 f'azfb_avg_corrs: {len(azfb_avg_corrs)}, '
                 f'all_azfb_corrs: {len(all_azfb_corrs)}, '
+                f'all_azb_corrs: {len(all_azb_corrs)}, '
+                f'azb_avg_corrs: {len(azb_avg_corrs)}, '
                 f'all_reactome_corrs (only if provided):'
                 f' {len(all_reactome_corrs)}, '
                 f'reactome_avg_corrs (only if provided):'
@@ -402,6 +407,8 @@ def get_corr_stats(so_pairs, run_single_proc: bool = False) \
         return {'all_axb_corrs': all_axb_corrs,
                 'axb_avg_corrs': axb_avg_corrs,
                 'top_axb_corrs': top_axb_corrs,
+                'azfb_avg_corrs': azfb_avg_corrs,
+                'all_azfb_corrs': all_azfb_corrs,
                 'all_azb_corrs': all_azb_corrs,
                 'azb_avg_corrs': azb_avg_corrs,
                 'all_reactome_corrs': all_reactome_corrs,

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -191,7 +191,7 @@ def get_pairs(corr_pairs):
             continue
         # Get all interaction types associated with given subject s and
         # object o
-        int_types = set(expl_df['expl type'][(expl_df['agA'] == s) &
+        int_types = set(expl_df['expl_type'][(expl_df['agA'] == s) &
                                              (expl_df['agB'] == o)].values)
         # Check intersection of types
         axb_types = {axb_colname, bxa_colname,
@@ -400,16 +400,16 @@ def get_interm_corr_stats_x(subj: str, obj: str, z_corr: pd.DataFrame,
     """
     path_rows = expl_df[(expl_df['agA'] == subj) &
                         (expl_df['agB'] == obj) &
-                        ((expl_df['expl type'] == axb_colname) |
-                         (expl_df['expl type'] == bxa_colname) |
-                         (expl_df['expl type'] == st_colname))]
+                        ((expl_df['expl_type'] == axb_colname) |
+                         (expl_df['expl_type'] == bxa_colname) |
+                         (expl_df['expl_type'] == st_colname))]
     x_set: Set[str] = set()
     for ix, path_row in path_rows.iterrows():
         # Data is in a 4-tuple for shared targets:
         # subj successors, obj predecessors, x intersection, x union
         # For a-x-b, b-x-a the data is not nested
         x_iter = path_row['expl data'][2] if \
-            path_row['expl type'] == st_colname else path_row['expl data']
+            path_row['expl_type'] == st_colname else path_row['expl data']
         x_names = \
             [x.name if isinstance(x, CentralDogma) else x for
              x in x_iter if x not in (subj, obj)]
@@ -450,16 +450,16 @@ def get_filtered_corr_stats_x(subj: str, obj: str, z_corr: pd.DataFrame,
     if _check_interesting(stats_row):
         path_rows = expl_df[(expl_df['agA'] == subj) &
                             (expl_df['agB'] == obj) &
-                            ((expl_df['expl type'] == axb_colname) |
-                             (expl_df['expl type'] == bxa_colname) |
-                             (expl_df['expl type'] == st_colname))]
+                            ((expl_df['expl_type'] == axb_colname) |
+                             (expl_df['expl_type'] == bxa_colname) |
+                             (expl_df['expl_type'] == st_colname))]
         x_set: Set[str] = set()
         for ix, path_row in path_rows.iterrows():
             # Data is in a 4-tuple for shared targets:
             # subj successors, obj predecessors, x intersection, x union
             # For a-x-b, b-x-a the data is not nested
             x_iter = path_row['expl data'][2] if \
-                path_row['expl type'] == st_colname else path_row['expl data']
+                path_row['expl_type'] == st_colname else path_row['expl data']
             x_names = \
                 [x.name if isinstance(x, CentralDogma) else x for
                  x in x_iter if x not in (subj, obj)]

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -497,7 +497,7 @@ def _check_interesting(stats_row: pd.DataFrame) -> bool:
         If the pair passes the filter
     """
     ab = stats_row[ab_colname].bool()
-    ba = stats_row[ab_colname].bool()
+    ba = stats_row[ba_colname].bool()
     st = stats_row[st_colname].bool()
     axb = stats_row[axb_colname].bool()
     bxa = stats_row[bxa_colname].bool()

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -190,14 +190,8 @@ def get_pairs(corr_pairs):
     # Get global args
     expl_df = global_vars['expl_df']
 
-    # Pairs where a-x-b AND a-b explanation exists
-    pairs_axb_direct = set()
-
     # Pairs where a-x-b AND NOT a-b explanation exists
     pairs_axb_only = set()
-
-    # all a-x-b "pathway" explanations, should be union of the above two
-    pairs_any_axb = set()
 
     for s, o in corr_pairs:
         # Make sure we don't try to explain self-correlations
@@ -215,9 +209,6 @@ def get_pairs(corr_pairs):
                 in int_types:
             pairs_axb_only.add((s, o))
 
-    # The union should be all pairs where a-x-b explanations exist
-    ab_axb_union = pairs_axb_direct.union(pairs_axb_only)
-    assert ab_axb_union == pairs_any_axb
     return pairs_axb_only
 
 

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -558,9 +558,28 @@ def get_interm_corr_stats_zf(subj: str, obj: str, z_set: List[str],
     return [], []
 
 
-
-def get_interm_corr_stats_z(subj, obj, z_set, z_corr) \
+def get_interm_corr_stats_z(subj: str, obj: str, z_set: List[str],
+                            z_corr: pd.DataFrame) \
         -> Tuple[List[float], List[float]]:
+    """
+
+    Parameters
+    ----------
+    subj : str
+        The entity corresponding to A in A,B
+    obj : str
+        The entity corresponding to B in A,B
+    z_set : List[str]
+        A list of randomly sampled intermediate entities to get the a-z,
+        z-b correlations from
+    z_corr : pd.DataFrame
+        The correlation dataframe used to produce the input data in expl_df
+        and stats_df
+
+    Returns
+    -------
+    Tuple[List[str], List[str]]
+    """
     return _get_interm_corr_stats(subj, obj, z_set, z_corr)
 
 

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -52,9 +52,16 @@ def error_callback(err):
 
 
 class GlobalVars(object):
-    def __init__(self, df=None, z_cm=None, reactome=None, sampl=10):
-        if df is not None:
-            global_vars['df'] = df
+    def __init__(self,
+                 expl_df: pd.DataFrame = None,
+                 stats_df: pd.DataFrame = None,
+                 z_cm: pd.DataFrame = None,
+                 reactome: Dict[str, List[str]] = None,
+                 sampl: int = 10):
+        if expl_df is not None:
+            global_vars['expl_df'] = expl_df
+        if stats_df is not None:
+            global_vars['stats_df'] = stats_df
         if sampl:
             global_vars['subset_size'] = sampl
         if reactome:
@@ -97,7 +104,7 @@ class GlobalVars(object):
     @staticmethod
     def assert_vars():
         """Same as assert_global_vars but with the shared array as well"""
-        df_exists = global_vars.get('df', False) is not False
+        df_exists = global_vars.get('expl_df', False) is not False
         z_cm_exists = global_vars.get('z_cm', False) is not False
         reactome_exists = global_vars.get('reactome', False) is not False
         ssize_exists = global_vars.get('subset_size', False) is not False
@@ -164,7 +171,7 @@ def get_pairs_mp(ab_corr_pairs, max_proc=cpu_count(), max_pairs=10000):
 
 def get_pairs(corr_pairs):
     # Get global args
-    expl_df = global_vars['df']
+    expl_df = global_vars['expl_df']
 
     # Pairs where a-x-b AND a-b explanation exists
     pairs_axb_direct = set()
@@ -252,7 +259,8 @@ def get_corr_stats_mp(so_pairs, max_proc=cpu_count()):
 def get_corr_stats(so_pairs):
     try:
         global list_of_genes
-        df = global_vars['df']
+        expl_df = global_vars['expl_df']
+        stats_df = global_vars['stats_df']
         z_corr = global_vars['z_cm']
         reactome = global_vars.get('reactome')
         subset_size = global_vars['subset_size']
@@ -276,7 +284,7 @@ def get_corr_stats(so_pairs):
         for subj, obj in so_pairs:
             # Get x values
             (avg_x_corrs_per_ab, axb_corrs), x_len = \
-                get_interm_corr_stats_x(subj, obj, z_corr, df)
+                get_interm_corr_stats_x(subj, obj, z_corr, expl_df)
             all_axb_corrs += axb_corrs
             if len(avg_x_corrs_per_ab) > 0:
                 max_magn_avg = max(avg_x_corrs_per_ab)
@@ -352,7 +360,7 @@ def get_interm_corr_stats_x(subj: str, obj: str, z_corr: pd.DataFrame,
     obj : str
         The entity corresponding to B in A,B
     z_corr : pd.DataFrame
-        The correlation dataframe used to produce the input data in df
+        The correlation dataframe used to produce the input data in expl_df
     expl_df : pd.DataFrame
         The explanation data frame from the input data
 

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -443,9 +443,10 @@ def get_filtered_corr_stats_x(subj: str, obj: str, z_corr: pd.DataFrame,
     -------
     Tuple[Tuple[List[float], List[float]], int]
     """
-    key_pair = expl_df[(expl_df['agA'] == subj) &
+    pair_key = expl_df[(expl_df['agA'] == subj) &
                        (expl_df['agB'] == obj)].pair.values[0]
-    stats_row = stats_df[stats_df.pair == key_pair]
+    # There should be only one row per pair_key
+    stats_row = stats_df[stats_df.pair == pair_key]
     if _check_interesting(stats_row):
         path_rows = expl_df[(expl_df['agA'] == subj) &
                             (expl_df['agB'] == obj) &
@@ -480,13 +481,13 @@ def _check_interesting(stats_row: pd.DataFrame) -> bool:
     bool
         If the pair passes the filter
     """
-    ab = stats_row[ab_colname]
-    ba = stats_row[ab_colname]
-    st = stats_row[st_colname]
-    axb = stats_row[axb_colname]
-    bxa = stats_row[bxa_colname]
-    react = stats_row[react_colname]
-    apriori = stats_row[apriori_colname]
+    ab = stats_row[ab_colname].bool()
+    ba = stats_row[ab_colname].bool()
+    st = stats_row[st_colname].bool()
+    axb = stats_row[axb_colname].bool()
+    bxa = stats_row[bxa_colname].bool()
+    react = stats_row[react_colname].bool()
+    apriori = stats_row[apriori_colname].bool()
 
     return (axb or bxa or st) and \
         not ab and not ba and not react and not apriori

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -73,8 +73,7 @@ class GlobalVars(object):
             list_of_genes = Array(c_wchar_p,
                                   np.array(z_cm.columns.values),
                                   lock=False)
-        if verbose:
-            global_vars['verbose'] = verbose
+        global_vars['verbose'] = verbose
 
     @staticmethod
     def update_global_vars(**kwargs):

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -263,7 +263,7 @@ def get_corr_stats_mp(so_pairs, max_proc=cpu_count()):
     return results
 
 
-def get_corr_stats(so_pairs):
+def get_corr_stats(so_pairs) -> Dict[str, List[float]]:
     try:
         global list_of_genes
         expl_df = global_vars['expl_df']
@@ -493,11 +493,13 @@ def _check_interesting(stats_row: pd.DataFrame) -> bool:
         not ab and not ba and not react and not apriori
 
 
-def get_interm_corr_stats_z(subj, obj, z_set, z_corr):
+def get_interm_corr_stats_z(subj, obj, z_set, z_corr) \
+        -> Tuple[List[float], List[float]]:
     return _get_interm_corr_stats(subj, obj, z_set, z_corr)
 
 
-def get_interm_corr_stats_reactome(subj, obj, reactome, z_corr):
+def get_interm_corr_stats_reactome(subj, obj, reactome, z_corr) \
+        -> Tuple[Tuple[List[float], List[float]], int]:
     pathways_by_gene, genes_by_pathway, _ = reactome
     subj_up = _hgncsym2up(subj)
     if subj_up is None:
@@ -518,7 +520,9 @@ def get_interm_corr_stats_reactome(subj, obj, reactome, z_corr):
     return ([], []), len(hgnc_gene_set)
 
 
-def _get_interm_corr_stats(a, b, y_set, z_corr):
+def _get_interm_corr_stats(a: str, b: str, y_set: Union[List[str], Set[str]],
+                           z_corr: pd.DataFrame) \
+        -> Tuple[List[float], List[float]]:
     # Get a list of the maximum ax-bx average per pair
     avg_y_corrs_per_ab = []
 
@@ -565,7 +569,7 @@ def _get_interm_corr_stats(a, b, y_set, z_corr):
     return avg_y_corrs_per_ab, all_ayb_corrs
 
 
-def _hgncsym2up(hgnc_symb):
+def _hgncsym2up(hgnc_symb: str) -> str:
     hgnc_id = get_current_hgnc_id(hgnc_symb)
     if isinstance(hgnc_id, list):
         ix = 0
@@ -581,5 +585,5 @@ def _hgncsym2up(hgnc_symb):
     return upid
 
 
-def _up2hgncsym(up_id):
+def _up2hgncsym(up_id: str) -> str:
     return get_hgnc_name(uniprot_ids_reverse.get(up_id))

--- a/depmap_analysis/scripts/corr_stats_async.py
+++ b/depmap_analysis/scripts/corr_stats_async.py
@@ -57,7 +57,8 @@ class GlobalVars(object):
                  stats_df: pd.DataFrame = None,
                  z_cm: pd.DataFrame = None,
                  reactome: Dict[str, List[str]] = None,
-                 sampl: int = 10):
+                 sampl: int = 10,
+                 verbose: bool = False):
         if expl_df is not None:
             global_vars['expl_df'] = expl_df
         if stats_df is not None:
@@ -72,6 +73,8 @@ class GlobalVars(object):
             list_of_genes = Array(c_wchar_p,
                                   np.array(z_cm.columns.values),
                                   lock=False)
+        if verbose:
+            global_vars['verbose'] = verbose
 
     @staticmethod
     def update_global_vars(**kwargs):
@@ -552,12 +555,13 @@ def _get_interm_corr_stats(a, b, y_set, z_corr):
                 f'({a.__class__}), object {str(b)} '
                 f'({b.__class__}) and intermediate {str(y)} ({y.__class__})'
             ) from ke
-    if c['y_corr_none'] > 0:
-        logger.warning(f'Skipped {c["y_corr_none"]} pairs because of nan '
-                       f'values')
-    if c['y_none'] > 0:
-        logger.warning(f'Skipped {c["y_none"]} pairs because y was None or '
-                       f'self correlation or y, a or b not being in z_corr')
+    if global_vars['verbose']:
+        if c['y_corr_none'] > 0:
+            logger.warning(f'Skipped {c["y_corr_none"]} pairs because of nan '
+                           f'values')
+        if c['y_none'] > 0:
+            logger.warning(f'Skipped {c["y_none"]} pairs because y was None or '
+                           f'self correlation or y, a or b not being in z_corr')
     return avg_y_corrs_per_ab, all_ayb_corrs
 
 

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -133,7 +133,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
                 pairs_axb_only.add((s, o))
 
         # Check if we need to sample
-        if max_corr_pairs < len(pairs_axb_only):
+        if max_corr_pairs and max_corr_pairs < len(pairs_axb_only):
             logger.info(f'Down sampling number of pairs to {max_corr_pairs}')
             pairs_axb_only = random.sample(pairs_axb_only, max_corr_pairs)
 

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -74,11 +74,11 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
     # very small set)
     logger.info("Filter expl_df to pathway, direct, shared_target")
     expl_df = expl_df[
-        (expl_df['expl type'] == axb_colname) |
-        (expl_df['expl type'] == bxa_colname) |
-        (expl_df['expl type'] == ab_colname) |
-        (expl_df['expl type'] == ba_colname) |
-        (expl_df['expl type'] == st_colname)
+        (expl_df['expl_type'] == axb_colname) |
+        (expl_df['expl_type'] == bxa_colname) |
+        (expl_df['expl_type'] == ab_colname) |
+        (expl_df['expl_type'] == ba_colname) |
+        (expl_df['expl_type'] == st_colname)
     ]
 
     # Re-map the columns containing string representations of objects
@@ -113,7 +113,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
 
             # Get all interaction types associated with s and o
             int_types = \
-                set(expl_df['expl type'][(expl_df['agA'] == s) &
+                set(expl_df['expl_type'][(expl_df['agA'] == s) &
                                          (expl_df['agB'] == o)].values)
 
             # Filter to a-x-b, b-x-a, st

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -105,8 +105,6 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
                                       max_pairs=max_corr_pairs)
     else:
         logger.info('Assembling axb subj-obj pairs linearly')
-        # Pairs where a-x-b AND a-b explanation exists
-        pairs_axb_direct = set()
 
         # Pairs where a-x-b AND NOT a-b explanation exists
         pairs_axb_only = set()

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -6,21 +6,28 @@ import ast
 import pickle
 import logging
 from os import path
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-from .corr_stats_async import get_corr_stats_mp, GlobalVars, get_pairs_mp
 from depmap_analysis.scripts.depmap_script_expl_funcs import axb_colname, \
     bxa_colname, ab_colname, ba_colname, st_colname
+from .corr_stats_async import get_corr_stats_mp, GlobalVars, get_pairs_mp
 
 logger = logging.getLogger('DepMap Corr Stats')
 logger.setLevel(logging.INFO)
 
 
-def main(expl_df, z_corr, reactome=None, eval_str=False, max_proc=None,
-         max_corr_pairs=10000, do_mp_pairs=True):
+def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
+         reactome: Optional[Tuple[Dict[str, List[str]],
+                                  Dict[str, List[str]],
+                                  Dict[str, str]]] = None,
+         eval_str: Optional[bool] = False,
+         max_proc: Optional[int] = None,
+         max_corr_pairs: Optional[int] = 10000,
+         do_mp_pairs: Optional[bool] = True):
     """Get statistics of the correlations associated with different
     explanation types
 
@@ -28,7 +35,12 @@ def main(expl_df, z_corr, reactome=None, eval_str=False, max_proc=None,
     ----------
     expl_df: pd.DataFrame
         A pd.DataFrame containing all available explanations for the pairs
-        of genes in z_corr
+        of genes in z_corr. Available in the DepmapExplainer as
+        DepmapExplainer.expl_df.
+    stats_df: pd.DataFrame
+        A pd.DataFrame containing all checked A-B pairs and if they are
+        explained or not. Available in the DepmapExplainer as
+        DepmapExplainer.stats_df.
     z_corr : pd.DataFrame
         A pd.DataFrame of correlation z scores
     reactome : tuple[dict]|list[dict]
@@ -77,7 +89,7 @@ def main(expl_df, z_corr, reactome=None, eval_str=False, max_proc=None,
     all_ab_corr_pairs = set(map(lambda p: tuple(p),
                                 expl_df[['agA', 'agB']].values))
 
-    gbv = GlobalVars(df=expl_df, sampl=16)
+    gbv = GlobalVars(expl_df=expl_df, stats_df=stats_df, sampl=16)
     if do_mp_pairs and len(all_ab_corr_pairs) > 10000:
         # Do multiprocessing
         logger.info('Getting axb subj-obj pairs through multiprocessing')

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -28,7 +28,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
                                   Dict[str, str]]] = None,
          eval_str: Optional[bool] = False,
          max_proc: Optional[int] = None,
-         max_corr_pairs: Optional[int] = 10000,
+         max_corr_pairs: int = 10000,
          do_mp_pairs: Optional[bool] = True,
          run_linear: bool = False) -> Results:
     """Get statistics of the correlations associated with different

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -94,7 +94,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
     if do_mp_pairs and len(all_ab_corr_pairs) > 10000:
         # Do multiprocessing
         logger.info('Getting axb subj-obj pairs through multiprocessing')
-        gbv.assert_global_vars({'df'})
+        gbv.assert_global_vars({'expl_df', 'stats_df'})
         pairs_axb_only = get_pairs_mp(all_ab_corr_pairs, max_proc=max_proc,
                                       max_pairs=max_corr_pairs)
     else:
@@ -139,7 +139,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
         options['max_proc'] = max_proc
 
     # Set and assert existence of global variables
-    assert_vars = {'z_cm', 'df'}
+    assert_vars = {'z_cm', 'expl_df', 'stats_df'}
     if reactome is not None:
         gbv.update_global_vars(z_cm=z_corr, reactome=reactome)
         assert_vars.add('reactome')

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -157,7 +157,8 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
     if gbv.assert_global_vars(assert_vars):
         all_x_corrs_no_direct, avg_x_corrs_no_direct, top_x_corrs_no_direct, \
             all_azb_corrs_no_direct, azb_avg_corrs_no_direct, \
-            all_reactome_corrs, reactome_avg_corrs = \
+            all_reactome_corrs, reactome_avg_corrs, \
+            axb_filtered_avg_corrs, all_axb_filtered_corrs = \
             get_corr_stats_mp(**options)
     else:
         raise ValueError('Global variables could not be set')
@@ -168,7 +169,9 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
                             'all_azb_corrs': all_azb_corrs_no_direct,
                             'azb_avg_corrs': azb_avg_corrs_no_direct,
                             'all_reactome_corrs': all_reactome_corrs,
-                            'reactome_avg_corrs': reactome_avg_corrs}}
+                            'reactome_avg_corrs': reactome_avg_corrs,
+                            'all_x_filtered_corrs': all_axb_filtered_corrs,
+                            'avg_x_filtered_corrs': axb_filtered_avg_corrs}}
 
 
 if __name__ == '__main__':

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -15,7 +15,8 @@ import matplotlib.pyplot as plt
 
 from depmap_analysis.scripts.depmap_script_expl_funcs import axb_colname, \
     bxa_colname, ab_colname, ba_colname, st_colname
-from .corr_stats_async import get_corr_stats_mp, GlobalVars, get_pairs_mp
+from .corr_stats_async import get_corr_stats_mp, GlobalVars, get_pairs_mp, \
+    Results
 
 logger = logging.getLogger('DepMap Corr Stats')
 logger.setLevel(logging.INFO)
@@ -29,8 +30,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
          max_proc: Optional[int] = None,
          max_corr_pairs: Optional[int] = 10000,
          do_mp_pairs: Optional[bool] = True,
-         run_linear: bool = False) \
-        -> Dict[str, List[float]]:
+         run_linear: bool = False) -> Results:
     """Get statistics of the correlations associated with different
     explanation types
 
@@ -72,7 +72,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
 
     Returns
     -------
-    dict
+    Results
         A Dict containing correlation data for different explanations
     """
     # Limit to any a-x-b OR a-b expl (this COULD include explanations where
@@ -158,23 +158,11 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
         logger.info('No reactome file provided')
         gbv.update_global_vars(z_cm=z_corr)
     if gbv.assert_global_vars(assert_vars):
-        all_x_corrs_no_direct, avg_x_corrs_no_direct, top_x_corrs_no_direct, \
-            all_azb_corrs_no_direct, azb_avg_corrs_no_direct, \
-            all_reactome_corrs, reactome_avg_corrs, \
-            axb_filtered_avg_corrs, all_axb_filtered_corrs = \
-            get_corr_stats_mp(**options)
+        results: Results = get_corr_stats_mp(**options)
     else:
         raise ValueError('Global variables could not be set')
 
-    return {'all_x_corrs': all_x_corrs_no_direct,
-            'avg_x_corrs': avg_x_corrs_no_direct,
-            'top_x_corrs': top_x_corrs_no_direct,
-            'all_azb_corrs': all_azb_corrs_no_direct,
-            'azb_avg_corrs': azb_avg_corrs_no_direct,
-            'all_reactome_corrs': all_reactome_corrs,
-            'reactome_avg_corrs': reactome_avg_corrs,
-            'all_x_filtered_corrs': all_axb_filtered_corrs,
-            'avg_x_filtered_corrs': axb_filtered_avg_corrs}
+    return results
 
 
 if __name__ == '__main__':

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -28,7 +28,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
          max_proc: Optional[int] = None,
          max_corr_pairs: Optional[int] = 10000,
          do_mp_pairs: Optional[bool] = True) \
-        -> Dict[str, Dict[str, List[float]]]:
+        -> Dict[str, List[float]]:
     """Get statistics of the correlations associated with different
     explanation types
 
@@ -155,15 +155,15 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
     else:
         raise ValueError('Global variables could not be set')
 
-    return {'axb_not_dir': {'all_x_corrs': all_x_corrs_no_direct,
-                            'avg_x_corrs': avg_x_corrs_no_direct,
-                            'top_x_corrs': top_x_corrs_no_direct,
-                            'all_azb_corrs': all_azb_corrs_no_direct,
-                            'azb_avg_corrs': azb_avg_corrs_no_direct,
-                            'all_reactome_corrs': all_reactome_corrs,
-                            'reactome_avg_corrs': reactome_avg_corrs,
-                            'all_x_filtered_corrs': all_axb_filtered_corrs,
-                            'avg_x_filtered_corrs': axb_filtered_avg_corrs}}
+    return {'all_x_corrs': all_x_corrs_no_direct,
+            'avg_x_corrs': avg_x_corrs_no_direct,
+            'top_x_corrs': top_x_corrs_no_direct,
+            'all_azb_corrs': all_azb_corrs_no_direct,
+            'azb_avg_corrs': azb_avg_corrs_no_direct,
+            'all_reactome_corrs': all_reactome_corrs,
+            'reactome_avg_corrs': reactome_avg_corrs,
+            'all_x_filtered_corrs': all_axb_filtered_corrs,
+            'avg_x_filtered_corrs': axb_filtered_avg_corrs}
 
 
 if __name__ == '__main__':

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -86,7 +86,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
         expl_df['expl data'] = \
             expl_df['expl data'].apply(lambda x: ast.literal_eval(x))
 
-    # Get all correlation pairs
+    # Get all correlation pairs that were explained
     all_ab_corr_pairs = set(map(lambda p: tuple(p),
                                 expl_df[['agA', 'agB']].values))
 
@@ -131,15 +131,6 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
         logger.info('Removing self correlations')
         diag_val = z_corr.loc[z_corr.columns[0], z_corr.columns[0]]
         z_corr = z_corr[z_corr != diag_val]
-
-    # a-x-b AND direct
-    """
-    logger.info("Getting correlations for a-x-b AND direct")
-    all_x_corrs_direct, avg_x_corrs_direct, top_x_corrs_direct, \
-            all_azb_corrs_direct, azb_avg_corrs_direct = \
-        get_corr_stats(df=expl_df, crispr_cm=crispr_corr_matrix,
-                       rnai_cm=rnai_corr_matrix, so_pairs=pairs_axb_direct)
-    """
 
     # a-x-b AND NOT direct
     logger.info("Getting correlations for a-x-b AND NOT direct")

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -4,6 +4,7 @@ is an intermediate between gene pair a-b.
 import sys
 import ast
 import pickle
+import random
 import logging
 from os import path
 from typing import Dict, List, Optional, Tuple
@@ -130,6 +131,11 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
                     ab_colname not in int_types and \
                     ba_colname not in int_types:
                 pairs_axb_only.add((s, o))
+
+        # Check if we need to sample
+        if max_corr_pairs < len(pairs_axb_only):
+            logger.info(f'Down sampling number of pairs to {max_corr_pairs}')
+            pairs_axb_only = random.sample(pairs_axb_only, max_corr_pairs)
 
     # Check for and remove self correlations
     if not np.isnan(z_corr.loc[z_corr.columns[0], z_corr.columns[0]]):

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -149,12 +149,12 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
 
     # Set and assert existence of global variables
     assert_vars = {'z_cm', 'expl_df', 'stats_df'}
+    gbv.update_global_vars(z_cm=z_corr)
     if reactome is not None:
-        gbv.update_global_vars(z_cm=z_corr, reactome=reactome)
+        gbv.update_global_vars(reactome=reactome)
         assert_vars.add('reactome')
     else:
         logger.info('No reactome file provided')
-        gbv.update_global_vars(z_cm=z_corr)
     if gbv.assert_global_vars(assert_vars):
         results: Results = get_corr_stats_mp(**options)
     else:

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -27,7 +27,8 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
          eval_str: Optional[bool] = False,
          max_proc: Optional[int] = None,
          max_corr_pairs: Optional[int] = 10000,
-         do_mp_pairs: Optional[bool] = True) \
+         do_mp_pairs: Optional[bool] = True,
+         run_linear: bool = False) \
         -> Dict[str, List[float]]:
     """Get statistics of the correlations associated with different
     explanation types
@@ -63,6 +64,10 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
     do_mp_pairs : bool
         If True, get the pairs to process using multiprocessing if larger
         than 10 000. Default: True.
+    run_linear : bool
+        If True, run the script without multiprocessing. This option is good
+        when debugging or if the environment for some reason does not
+        support multiprocessing. Default: False.
 
     Returns
     -------
@@ -91,7 +96,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
                                 expl_df[['agA', 'agB']].values))
 
     gbv = GlobalVars(expl_df=expl_df, stats_df=stats_df, sampl=16)
-    if do_mp_pairs and len(all_ab_corr_pairs) > 10000:
+    if not run_linear and do_mp_pairs and len(all_ab_corr_pairs) > 10000:
         # Do multiprocessing
         logger.info('Getting axb subj-obj pairs through multiprocessing')
         gbv.assert_global_vars({'expl_df', 'stats_df'})
@@ -134,7 +139,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
 
     # a-x-b AND NOT direct
     logger.info("Getting correlations for a-x-b AND NOT direct")
-    options = {'so_pairs': pairs_axb_only}
+    options = {'so_pairs': pairs_axb_only, 'run_linear': run_linear}
     if max_proc:
         options['max_proc'] = max_proc
 

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -27,7 +27,8 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
          eval_str: Optional[bool] = False,
          max_proc: Optional[int] = None,
          max_corr_pairs: Optional[int] = 10000,
-         do_mp_pairs: Optional[bool] = True):
+         do_mp_pairs: Optional[bool] = True) \
+        -> Dict[str, Dict[str, List[float]]]:
     """Get statistics of the correlations associated with different
     explanation types
 

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -18,7 +18,7 @@ from depmap_analysis.scripts.depmap_script_expl_funcs import axb_colname, \
 from .corr_stats_async import get_corr_stats_mp, GlobalVars, get_pairs_mp, \
     Results
 
-logger = logging.getLogger('DepMap Corr Stats')
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/depmap_analysis/scripts/corr_stats_axb.py
+++ b/depmap_analysis/scripts/corr_stats_axb.py
@@ -52,7 +52,7 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
         to UP IDs). The third dict is expected to contain mappings from the
         Reactome IDs to their descriptions.
     eval_str : bool
-        If True, run ast.literal_eval() on the 'expl data' column of expl_df
+        If True, run ast.literal_eval() on the 'expl_data' column of expl_df
     max_proc : int > 0
         The maximum number of processes to run in the multiprocessing in
         get_corr_stats_mp. Default: multiprocessing.cpu_count()
@@ -88,8 +88,8 @@ def main(expl_df: pd.DataFrame, stats_df: pd.DataFrame, z_corr: pd.DataFrame,
 
     # Re-map the columns containing string representations of objects
     if eval_str:
-        expl_df['expl data'] = \
-            expl_df['expl data'].apply(lambda x: ast.literal_eval(x))
+        expl_df['expl_data'] = \
+            expl_df['expl_data'].apply(lambda x: ast.literal_eval(x))
 
     # Get all correlation pairs that were explained
     all_ab_corr_pairs = set(map(lambda p: tuple(p),

--- a/depmap_analysis/scripts/depmap_script_expl_funcs.py
+++ b/depmap_analysis/scripts/depmap_script_expl_funcs.py
@@ -24,7 +24,7 @@ from depmap_analysis.network_functions.net_functions import \
     gilda_normalization, INT_PLUS, INT_MINUS
 
 __all__ = ['get_ns_id_pybel_node', 'get_ns_id', 'normalize_corr_names',
-           'expl_functions', 'funcname_to_colname', 'apriori', 'axb_colname',
+           'expl_functions', 'funcname_to_colname', 'apriori_colname', 'axb_colname',
            'bxa_colname', 'ab_colname', 'ba_colname', 'st_colname',
            'sr_colname', 'sd_colname', 'cp_colname', 'react_colname',
            'react_funcname']
@@ -991,7 +991,7 @@ react_funcname = 'common_reactome_paths'
 expl_functions = {f.__name__: f for f in expl_func_list}
 
 # Set colnames to variables
-apriori = funcname_to_colname['apriori_explained']
+apriori_colname = funcname_to_colname['apriori_explained']
 axb_colname = funcname_to_colname['expl_axb']
 bxa_colname = funcname_to_colname['expl_bxa']
 ab_colname = funcname_to_colname['expl_ab']

--- a/depmap_analysis/scripts/gather_all_corr_stats.py
+++ b/depmap_analysis/scripts/gather_all_corr_stats.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        '--max-so-pairs', type=int,
+        '--max-so-pairs', type=int, default=10000,
         help='The maximum number of correlation pairs to process. If the '
              'number of eligble pairs is larger than this number, a random '
              'sample of max_so_pairs_size is used. Default: 10 000. If the '

--- a/depmap_analysis/scripts/gather_all_corr_stats.py
+++ b/depmap_analysis/scripts/gather_all_corr_stats.py
@@ -1,4 +1,3 @@
-import boto3
 import logging
 import argparse
 from math import floor
@@ -7,6 +6,7 @@ from pathlib import Path
 from itertools import count
 from datetime import datetime
 
+import boto3
 import pandas as pd
 
 from indra_db.util.s3_path import S3Path
@@ -85,9 +85,17 @@ if __name__ == '__main__':
              'pairs to process.'
     )
 
+    parser.add_argument(
+        '--single-proc', action='store_true',
+        help='Run all scripts on a single process. This option is good when '
+             'debugging or if the environment for some reason does not '
+             'support multiprocessing. Default: False.'
+    )
+
     args = parser.parse_args()
     base_path: str = args.base_path
     outdir: str = args.outdir
+    single_proc: bool = args.single_proc
 
     if base_path.startswith('s3://') or outdir.startswith('s3://'):
         s3 = boto3.client('s3')
@@ -169,13 +177,16 @@ if __name__ == '__main__':
                                       max_proc=max_proc,
                                       index_counter=indexer,
                                       max_so_pairs_size=args.max_so_pairs,
-                                      mp_pairs=args.mp_pairs)
+                                      mp_pairs=args.mp_pairs,
+                                      run_linear=single_proc)
 
             explainer.plot_dists(outdir=explainer_out,
-                                 z_corr=None, show_plot=False,
+                                 z_corr=None,
+                                 show_plot=False,
                                  index_counter=indexer,
                                  max_so_pairs_size=args.max_so_pairs,
-                                 mp_pairs=args.mp_pairs)
+                                 mp_pairs=args.mp_pairs,
+                                 run_linear=single_proc)
         else:
             if not _exists(explainer_file):
                 raise FileNotFoundError(f'{explainer_file} does not exist')

--- a/depmap_analysis/scripts/gather_all_corr_stats.py
+++ b/depmap_analysis/scripts/gather_all_corr_stats.py
@@ -187,6 +187,13 @@ if __name__ == '__main__':
                                  max_so_pairs_size=args.max_so_pairs,
                                  mp_pairs=args.mp_pairs,
                                  run_linear=single_proc)
+            explainer.plot_interesting(outdir=explainer_out,
+                                       z_corr=None,
+                                       show_plot=False,
+                                       index_counter=indexer,
+                                       max_so_pairs_size=args.max_so_pairs,
+                                       mp_pairs=args.mp_pairs,
+                                       run_linear=single_proc)
         else:
             if not _exists(explainer_file):
                 raise FileNotFoundError(f'{explainer_file} does not exist')

--- a/depmap_analysis/scripts/gather_all_corr_stats.py
+++ b/depmap_analysis/scripts/gather_all_corr_stats.py
@@ -112,6 +112,9 @@ if __name__ == '__main__':
         output_dir = Path(outdir)
 
     dry = args.dry
+    if dry:
+        logger.info('DRY RUN: no calculations are run but file errors are '
+                    'raised for missing files')
 
     if args.max_proc:
         max_proc = floor(args.max_proc)

--- a/depmap_analysis/util/statistics.py
+++ b/depmap_analysis/util/statistics.py
@@ -447,6 +447,8 @@ class DepMapExplainer:
                  color='b', alpha=0.3)
         plt.hist(all_ind['avg_x_corrs'], bins='auto', density=True,
                  color='r', alpha=0.3)
+        plt.hist(all_ind['avg_x_filtered_corrs'], bins='auto', density=True,
+                 color='k', alpha=0.3)
         legend = ['A-X-B for all X', 'A-X-B for X in network']
         if len(all_ind['reactome_avg_corrs']):
             plt.hist(all_ind['reactome_avg_corrs'], bins='auto',

--- a/depmap_analysis/util/statistics.py
+++ b/depmap_analysis/util/statistics.py
@@ -273,7 +273,7 @@ class DepMapExplainer:
             if isinstance(z_corr, str):
                 z_corr = pd.read_hdf(z_corr)
             self.corr_stats_axb = axb_stats(
-                self.expl_df, z_corr=z_corr, reactome=reactome,
+                self.expl_df, self.stats_df, z_corr=z_corr, reactome=reactome,
                 eval_str=False, max_proc=max_proc,
                 max_corr_pairs=max_so_pairs_size, do_mp_pairs=mp_pairs
             )

--- a/depmap_analysis/util/statistics.py
+++ b/depmap_analysis/util/statistics.py
@@ -390,7 +390,7 @@ class DepMapExplainer:
             's3://' upload to s3. outdir must then have the form
             's3://<bucket>/<sub_dir>' where <bucket> must be specified and
             <sub_dir> is optional and may contain subdirectories.
-        z_corr : pd.DataFrame
+        z_corr : Optional[pd.DataFrame]
             A pd.DataFrame containing the correlation z scores used to
             create the statistics in this object
         reactome : tuple[dict]|list[dict]


### PR DESCRIPTION
This PR makes several updates to the post-processing script:
- [Pydantic's](https://pydantic-docs.helpmanual.io/) `BaseModel` is introduced as "data carrier" from the post-processing script to the caller.
- A new plot is added showing the distribution of correlations for intermediates whose explanation does _not_ include a-b, b-a, a-priori or reactome intermediates compared to the background of the same subset.
- The option to run the post-processing in a single process (good for debugging and contexts which don't support multi processing)

Other updates:
- Deprecated/unused code has been removed
- Expanded use of Typing